### PR TITLE
proxy through with `x-zitadel-forwarded`

### DIFF
--- a/apps/login/middleware.ts
+++ b/apps/login/middleware.ts
@@ -9,13 +9,14 @@ const INSTANCE = process.env.ZITADEL_API_URL;
 const SERVICE_USER_ID = process.env.ZITADEL_SERVICE_USER_ID as string;
 
 export function middleware(request: NextRequest) {
-  const requestHeaders = new Headers({
-    host: request.headers.get("host") ?? request.nextUrl.host,
-  });
+  const requestHeaders = new Headers({});
   requestHeaders.set("x-zitadel-login-client", SERVICE_USER_ID);
 
   const host = request.nextUrl.host;
-  requestHeaders.set("x-zitadel-forwarded", `host="${host}"`);
+  requestHeaders.set(
+    "x-zitadel-forwarded",
+    `host="${request.nextUrl.host}",host="${host}"`
+  );
 
   console.log(`host="${host}"`);
   const responseHeaders = new Headers();

--- a/apps/login/middleware.ts
+++ b/apps/login/middleware.ts
@@ -12,7 +12,11 @@ export function middleware(request: NextRequest) {
   const requestHeaders = new Headers();
   requestHeaders.set("x-zitadel-login-client", SERVICE_USER_ID);
 
-  requestHeaders.set("x-zitadel-forwarded", `host="${request.nextUrl.host}"`);
+  requestHeaders.set(
+    "x-zitadel-forwarded",
+    `host="${INSTANCE?.replace("https://", "")}"`
+  );
+
   // requestHeaders.delete("forwarded");
 
   const responseHeaders = new Headers();

--- a/apps/login/middleware.ts
+++ b/apps/login/middleware.ts
@@ -13,12 +13,10 @@ export function middleware(request: NextRequest) {
   requestHeaders.set("x-zitadel-login-client", SERVICE_USER_ID);
 
   const host = request.nextUrl.host;
-  requestHeaders.set(
-    "x-zitadel-forwarded",
-    `host="${request.nextUrl.host}",host="${host}"`
-  );
+  requestHeaders.set("x-zitadel-forwarded", `host="${host}"`);
 
   console.log(`host="${host}"`);
+  console.log(requestHeaders);
   const responseHeaders = new Headers();
   responseHeaders.set("Access-Control-Allow-Origin", "*");
   responseHeaders.set("Access-Control-Allow-Headers", "*");

--- a/apps/login/middleware.ts
+++ b/apps/login/middleware.ts
@@ -12,7 +12,7 @@ export function middleware(request: NextRequest) {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set("x-zitadel-login-client", SERVICE_USER_ID);
 
-  console.log(JSON.stringify(request.nextUrl));
+  console.log(JSON.stringify("host: " + request.nextUrl.host));
   requestHeaders.set("Forwarded", `host="${request.nextUrl.host}"`);
 
   const responseHeaders = new Headers();

--- a/apps/login/middleware.ts
+++ b/apps/login/middleware.ts
@@ -13,6 +13,10 @@ export function middleware(request: NextRequest) {
   requestHeaders.set("x-zitadel-login-client", SERVICE_USER_ID);
 
   console.log("host: " + request.nextUrl.host);
+  console.log("hostname: " + request.nextUrl.hostname);
+  console.log("href: " + request.nextUrl.href);
+  console.log("origin: " + request.nextUrl.origin);
+
   requestHeaders.set("Forwarded", `host="${request.nextUrl.host}"`);
 
   const responseHeaders = new Headers();

--- a/apps/login/middleware.ts
+++ b/apps/login/middleware.ts
@@ -12,7 +12,7 @@ export function middleware(request: NextRequest) {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set("x-zitadel-login-client", SERVICE_USER_ID);
 
-  console.log(JSON.stringify("host: " + request.nextUrl.host));
+  console.log("host: " + request.nextUrl.host);
   requestHeaders.set("Forwarded", `host="${request.nextUrl.host}"`);
 
   const responseHeaders = new Headers();

--- a/apps/login/middleware.ts
+++ b/apps/login/middleware.ts
@@ -12,14 +12,10 @@ export function middleware(request: NextRequest) {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set("x-zitadel-login-client", SERVICE_USER_ID);
 
-  const origin = new URL(
-    request.headers.get("origin") || request.nextUrl.origin
-  );
-
-  const host = origin.host;
-
+  const host = request.nextUrl.host;
   requestHeaders.set("Forwarded", `host="${host}"`);
 
+  console.log(`host="${host}"`);
   const responseHeaders = new Headers();
   responseHeaders.set("Access-Control-Allow-Origin", "*");
   responseHeaders.set("Access-Control-Allow-Headers", "*");

--- a/apps/login/middleware.ts
+++ b/apps/login/middleware.ts
@@ -9,7 +9,9 @@ const INSTANCE = process.env.ZITADEL_API_URL;
 const SERVICE_USER_ID = process.env.ZITADEL_SERVICE_USER_ID as string;
 
 export function middleware(request: NextRequest) {
-  const requestHeaders = new Headers({});
+  const requestHeaders = new Headers({
+    host: request.headers.get("host") ?? request.nextUrl.host,
+  });
   requestHeaders.set("x-zitadel-login-client", SERVICE_USER_ID);
 
   const host = request.nextUrl.host;

--- a/apps/login/middleware.ts
+++ b/apps/login/middleware.ts
@@ -9,7 +9,7 @@ const INSTANCE = process.env.ZITADEL_API_URL;
 const SERVICE_USER_ID = process.env.ZITADEL_SERVICE_USER_ID as string;
 
 export function middleware(request: NextRequest) {
-  const requestHeaders = new Headers(request.headers);
+  const requestHeaders = new Headers({});
   requestHeaders.set("x-zitadel-login-client", SERVICE_USER_ID);
 
   const host = request.nextUrl.host;

--- a/apps/login/middleware.ts
+++ b/apps/login/middleware.ts
@@ -13,7 +13,7 @@ export function middleware(request: NextRequest) {
   requestHeaders.set("x-zitadel-login-client", SERVICE_USER_ID);
 
   requestHeaders.set("x-zitadel-forwarded", `host="${request.nextUrl.host}"`);
-  requestHeaders.delete("forwarded");
+  // requestHeaders.delete("forwarded");
 
   const responseHeaders = new Headers();
   responseHeaders.set("Access-Control-Allow-Origin", "*");

--- a/apps/login/middleware.ts
+++ b/apps/login/middleware.ts
@@ -13,7 +13,7 @@ export function middleware(request: NextRequest) {
   requestHeaders.set("x-zitadel-login-client", SERVICE_USER_ID);
 
   const host = request.nextUrl.host;
-  requestHeaders.set("Forwarded", `host="${host}"`);
+  requestHeaders.set("forwarded", `host="${host}"`);
 
   console.log(`host="${host}"`);
   const responseHeaders = new Headers();

--- a/apps/login/middleware.ts
+++ b/apps/login/middleware.ts
@@ -9,14 +9,12 @@ const INSTANCE = process.env.ZITADEL_API_URL;
 const SERVICE_USER_ID = process.env.ZITADEL_SERVICE_USER_ID as string;
 
 export function middleware(request: NextRequest) {
-  const requestHeaders = new Headers({});
+  const requestHeaders = new Headers();
   requestHeaders.set("x-zitadel-login-client", SERVICE_USER_ID);
 
-  const host = request.nextUrl.host;
-  requestHeaders.set("x-zitadel-forwarded", `host="${host}"`);
+  requestHeaders.set("x-zitadel-forwarded", `host="${request.nextUrl.host}"`);
+  requestHeaders.delete("forwarded");
 
-  console.log(`host="${host}"`);
-  console.log(requestHeaders);
   const responseHeaders = new Headers();
   responseHeaders.set("Access-Control-Allow-Origin", "*");
   responseHeaders.set("Access-Control-Allow-Headers", "*");

--- a/apps/login/middleware.ts
+++ b/apps/login/middleware.ts
@@ -12,12 +12,13 @@ export function middleware(request: NextRequest) {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set("x-zitadel-login-client", SERVICE_USER_ID);
 
-  console.log("host: " + request.nextUrl.host);
-  console.log("hostname: " + request.nextUrl.hostname);
-  console.log("href: " + request.nextUrl.href);
-  console.log("origin: " + request.nextUrl.origin);
+  const origin = new URL(
+    request.headers.get("origin") || request.nextUrl.origin
+  );
 
-  requestHeaders.set("Forwarded", `host="${request.nextUrl.host}"`);
+  const host = origin.host;
+
+  requestHeaders.set("Forwarded", `host="${host}"`);
 
   const responseHeaders = new Headers();
   responseHeaders.set("Access-Control-Allow-Origin", "*");

--- a/apps/login/middleware.ts
+++ b/apps/login/middleware.ts
@@ -13,7 +13,7 @@ export function middleware(request: NextRequest) {
   requestHeaders.set("x-zitadel-login-client", SERVICE_USER_ID);
 
   const host = request.nextUrl.host;
-  requestHeaders.set("forwarded", `host="${host}"`);
+  requestHeaders.set("x-zitadel-forwarded", `host="${host}"`);
 
   console.log(`host="${host}"`);
   const responseHeaders = new Headers();

--- a/apps/login/middleware.ts
+++ b/apps/login/middleware.ts
@@ -12,6 +12,7 @@ export function middleware(request: NextRequest) {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set("x-zitadel-login-client", SERVICE_USER_ID);
 
+  console.log(JSON.stringify(request.nextUrl));
   requestHeaders.set("Forwarded", `host="${request.nextUrl.host}"`);
 
   const responseHeaders = new Headers();


### PR DESCRIPTION
### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] Jest unit tests ensure that components produce expected outputs on different inputs.
- [ ] Cypress integration tests ensure that login app pages work as expected. The ZITADEL API is mocked.
- [ ] No debug or dead code
- [ ] My code has no repetitions
