### PR TITLE
chore: add workflow for issues and prs to pm board

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -28,14 +28,14 @@ jobs:
          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
       - name: add pr
         uses: actions/add-to-project@v0.5.0
-        if: ${{ github.event_name == 'pull_request_target' && !contains(steps.checkUserMember.outputs.teams, 'engineers')}}
+        if: ${{ github.event_name == 'pull_request_target' && !contains(steps.checkUserMember.outputs.teams, 'engineers') && github.actor != 'app/dependabot'}}
         with:
           # You can target a repository in a different organization
           # to the issue
           project-url: https://github.com/orgs/zitadel/projects/2
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
       - uses: actions-ecosystem/action-add-labels@v1.1.0
-        if: ${{ github.event_name == 'pull_request_target' && !contains(steps.checkUserMember.outputs.teams, 'staff')}}
+        if: ${{ github.event_name == 'pull_request_target' && !contains(steps.checkUserMember.outputs.teams, 'staff') && github.actor != 'app/dependabot'}}
         with:
           github_token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labels: |

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,42 @@
+name: Add new issues to product management project
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue and community pr to project
+    runs-on: ubuntu-latest
+    steps:
+      - name: add issue
+        uses: actions/add-to-project@v0.5.0
+        if: ${{ github.event_name == 'issues' }}
+        with:
+          # You can target a repository in a different organization
+          # to the issue
+          project-url: https://github.com/orgs/zitadel/projects/2
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+      - uses: tspascoal/get-user-teams-membership@v3
+        id: checkUserMember
+        with:
+         username: ${{ github.actor }}
+         GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+      - name: add pr
+        uses: actions/add-to-project@v0.5.0
+        if: ${{ github.event_name == 'pull_request_target' && !contains(steps.checkUserMember.outputs.teams, 'engineers')}}
+        with:
+          # You can target a repository in a different organization
+          # to the issue
+          project-url: https://github.com/orgs/zitadel/projects/2
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+      - uses: actions-ecosystem/action-add-labels@v1.1.0
+        if: ${{ github.event_name == 'pull_request_target' && !contains(steps.checkUserMember.outputs.teams, 'staff')}}
+        with:
+          github_token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labels: |
+            os-contribution


### PR DESCRIPTION
automatically ad prs of non engineers to board and label community prs

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] Jest unit tests ensure that components produce expected outputs on different inputs.
- [ ] Cypress integration tests ensure that login app pages work as expected. The ZITADEL API is mocked.
- [ ] No debug or dead code
- [ ] My code has no repetitions
