### PR TITLE
Promote qa to prod

### DIFF
--- a/apps/login/src/app/api/loginname/route.ts
+++ b/apps/login/src/app/api/loginname/route.ts
@@ -112,18 +112,24 @@ export async function POST(request: NextRequest) {
           if (
             !orgToRegisterOn &&
             loginName &&
-            ORG_SUFFIX_REGEX.test(loginName) &&
-            loginSettings.allowDomainDiscovery
+            ORG_SUFFIX_REGEX.test(loginName)
           ) {
             const matched = ORG_SUFFIX_REGEX.exec(loginName);
             const suffix = matched?.[1] ?? "";
 
             // this just returns orgs where the suffix is set as primary domain
             const orgs = await getOrgsByDomain(suffix);
-            orgToRegisterOn =
+            const orgToCheckForDiscovery =
               orgs.result && orgs.result.length === 1
                 ? orgs.result[0].id
                 : undefined;
+
+            const orgLoginSettings = await getLoginSettings(
+              orgToCheckForDiscovery,
+            );
+            if (orgLoginSettings?.allowDomainDiscovery) {
+              orgToRegisterOn = orgToCheckForDiscovery;
+            }
           }
 
           const params: any = {};

--- a/apps/login/src/app/api/loginname/route.ts
+++ b/apps/login/src/app/api/loginname/route.ts
@@ -117,6 +117,7 @@ export async function POST(request: NextRequest) {
             const matched = ORG_SUFFIX_REGEX.exec(loginName);
             const suffix = matched?.[1] ?? "";
 
+            // this just returns orgs where the suffix is set as primary domain
             const orgs = await getOrgsByDomainSuffix(suffix);
             orgToRegisterOn =
               orgs.result && orgs.result.length === 1

--- a/apps/login/src/app/api/loginname/route.ts
+++ b/apps/login/src/app/api/loginname/route.ts
@@ -2,7 +2,7 @@ import { idpTypeToSlug } from "@/lib/idp";
 import {
   getActiveIdentityProviders,
   getLoginSettings,
-  getOrgsByDomainSuffix,
+  getOrgsByDomain,
   listAuthenticationMethodTypes,
   listUsers,
   startIdentityProviderFlow,
@@ -112,13 +112,14 @@ export async function POST(request: NextRequest) {
           if (
             !orgToRegisterOn &&
             loginName &&
-            ORG_SUFFIX_REGEX.test(loginName)
+            ORG_SUFFIX_REGEX.test(loginName) &&
+            loginSettings.allowDomainDiscovery
           ) {
             const matched = ORG_SUFFIX_REGEX.exec(loginName);
             const suffix = matched?.[1] ?? "";
 
             // this just returns orgs where the suffix is set as primary domain
-            const orgs = await getOrgsByDomainSuffix(suffix);
+            const orgs = await getOrgsByDomain(suffix);
             orgToRegisterOn =
               orgs.result && orgs.result.length === 1
                 ? orgs.result[0].id

--- a/apps/login/src/app/login/route.ts
+++ b/apps/login/src/app/login/route.ts
@@ -6,7 +6,7 @@ import {
   createCallback,
   getActiveIdentityProviders,
   getAuthRequest,
-  getOrgByDomain,
+  getOrgsByDomain,
   listSessions,
   startIdentityProviderFlow,
 } from "@/lib/zitadel";
@@ -147,8 +147,10 @@ export async function GET(request: NextRequest) {
           const matched = ORG_DOMAIN_SCOPE_REGEX.exec(orgDomainScope);
           const orgDomain = matched?.[1] ?? "";
           if (orgDomain) {
-            const org = await getOrgByDomain(orgDomain);
-            organization = org?.org?.id ?? "";
+            const orgs = await getOrgsByDomain(orgDomain);
+            if (orgs.result && orgs.result.length === 1) {
+              organization = orgs.result[0].id ?? "";
+            }
           }
         }
       }

--- a/apps/login/src/lib/zitadel.ts
+++ b/apps/login/src/lib/zitadel.ts
@@ -295,7 +295,16 @@ export async function listUsers({
 
 export async function getOrgsByDomainSuffix(domain: string) {
   return orgService.listOrganizations(
-    { queries: [{ query: { case: "domainQuery", value: { domain } } }] },
+    {
+      queries: [
+        {
+          query: {
+            case: "domainQuery",
+            value: { domain, method: TextQueryMethod.EQUALS },
+          },
+        },
+      ],
+    },
     {},
   );
 }

--- a/apps/login/src/lib/zitadel.ts
+++ b/apps/login/src/lib/zitadel.ts
@@ -293,7 +293,7 @@ export async function listUsers({
   );
 }
 
-export async function getOrgsByDomainSuffix(domain: string) {
+export async function getOrgsByDomain(domain: string) {
   return orgService.listOrganizations(
     {
       queries: [

--- a/apps/login/src/lib/zitadel.ts
+++ b/apps/login/src/lib/zitadel.ts
@@ -5,6 +5,7 @@ import {
   createUserServiceClient,
   createIdpServiceClient,
   makeReqCtx,
+  createOrganizationServiceClient,
 } from "@zitadel/client/v2";
 import { createManagementServiceClient } from "@zitadel/client/v1";
 import { createServerTransport } from "@zitadel/node";
@@ -36,10 +37,10 @@ const transport = createServerTransport(
 );
 
 export const sessionService = createSessionServiceClient(transport);
-export const managementService = createManagementServiceClient(transport);
 export const userService = createUserServiceClient(transport);
 export const oidcService = createOIDCServiceClient(transport);
 export const idpService = createIdpServiceClient(transport);
+export const orgService = createOrganizationServiceClient(transport);
 
 export const settingsService = createSettingsServiceClient(transport);
 
@@ -292,8 +293,11 @@ export async function listUsers({
   );
 }
 
-export async function getOrgByDomain(domain: string) {
-  return managementService.getOrgByDomainGlobal({ domain }, {});
+export async function getOrgsByDomainSuffix(domain: string) {
+  return orgService.listOrganizations(
+    { queries: [{ query: { case: "domainQuery", value: { domain } } }] },
+    {},
+  );
 }
 
 export async function startIdentityProviderFlow({

--- a/packages/zitadel-client/src/v3alpha.ts
+++ b/packages/zitadel-client/src/v3alpha.ts
@@ -1,6 +1,6 @@
-import { UserSchemaService } from "@zitadel/proto/zitadel/user/schema/v3alpha/user_schema_service_connect";
-import { UserService } from "@zitadel/proto/zitadel/user/v3alpha/user_service_connect";
+import { ZITADELUsers } from "@zitadel/proto/zitadel/resources/user/v3alpha/user_service_connect";
+import { ZITADELUserSchemas } from "@zitadel/proto/zitadel/resources/userschema/v3alpha/user_schema_service_connect.js";
 import { createClientFor } from "./helpers";
 
-export const createUserSchemaServiceClient = createClientFor(UserSchemaService);
-export const createUserServiceClient = createClientFor(UserService);
+export const createUserSchemaServiceClient = createClientFor(ZITADELUserSchemas);
+export const createUserServiceClient = createClientFor(ZITADELUsers);


### PR DESCRIPTION
This PR adds org discovery on register. If a user enters an email for login, orgs are searched according to the suffix of the email if no user was found and the user is redirected to the register page of the detected organization.

Closes #81 

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [ ] Cypress integration tests ensure that login app pages work as expected. The ZITADEL API is mocked.
- [x] No debug or dead code
- [x] My code has no repetitions
