### PR TITLE
chore(test:integration): install cypress binary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
           cache: 'pnpm'
 
       - uses: actions/cache@v4.0.2
-        name: Setup Cypress cache
+        name: Setup Cypress binary cache
         with:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-binary-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -56,7 +56,7 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
-        # We can cache the Playwright binary cache independently from the pnpm cache, because we install it separately.
+        # We can cache the Playwright binary independently from the pnpm cache, because we install it separately.
         # After pnpm install --frozen-lockfile, we can get the version so we only have to download the binary once per version.
       - run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d ' ' -f 2)" >> $GITHUB_ENV
         if: ${{ matrix.command == 'test:acceptance' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,14 +34,14 @@ jobs:
       - name: Setup Buf
         uses: bufbuild/buf-setup-action@v1.45.0
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4.0.0
+
       - name: Setup Node.js 20.x
         uses: actions/setup-node@v4.0.2
         with:
           node-version: 20.x
           cache: 'pnpm'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4.0.0
 
       - uses: actions/cache@v4.0.2
         name: Setup Cypress cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,23 +57,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install Dependencies
-        run: CYPRESS_INSTALL_BINARY=0 pnpm install
-
-      - run: echo "CYPRESS_VERSION=$(pnpm list -r | grep cypress | cut -d ' ' -f 2)" >> $GITHUB_ENV
-        if: ${{ matrix.command == 'test:integration' }}
-
-      - uses: actions/cache@v4.0.2
-        name: Setup Cypress binary cache
-        with:
-          path: ~/.cache/Cypress
-          key: ${{ runner.os }}-cypress-binary-${{ env.CYPRESS_VERSION }}
-          restore-keys: |
-            ${{ runner.os }}-cypress-binary-
-        if: ${{ matrix.command == 'test:integration' }}
-
-      - name: Install Cypress Browsers
-        run: pnpm install
-        if: ${{ matrix.command == 'test:integration' }}
+        run: CYPRESS_INSTALL_BINARY=${{ matrix.command == 'test:integration' }} pnpm install --frozen-lockfile
 
       - run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d ' ' -f 2)" >> $GITHUB_ENV
         if: ${{ matrix.command == 'test:acceptance' }}
@@ -99,7 +83,7 @@ jobs:
         run: ZITADEL_DEV_UID=root pnpm run-zitadel
         if: ${{ matrix.command == 'test:acceptance' }}
 
-      - name: Install Playwright Browsers
+      - name: Create Production Build
         run: pnpm build
         if: ${{ matrix.command == 'test:acceptance' }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,32 +38,32 @@ jobs:
         uses: actions/setup-node@v4.0.2
         with:
           node-version: 20.x
+          cache: 'pnpm'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.0.0
 
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
       - uses: actions/cache@v4.0.2
-        name: Setup pnpm cache
+        name: Setup Cypress cache
         with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-binary-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-cypress-binary-
+        # The Cypress binary cache needs to be updated together with the pnpm dependencies cache.
+        # That's why we don't conditionally cache it using if: ${{ matrix.command == 'test:integration' }}
 
       - name: Install Dependencies
-        run: CYPRESS_INSTALL_BINARY=${{ matrix.command == 'test:integration' }} pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
+        # We can cache the Playwright binary cache independently from the pnpm cache, because we install it separately.
+        # After pnpm install --frozen-lockfile, we can get the version so we only have to download the binary once per version.
       - run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d ' ' -f 2)" >> $GITHUB_ENV
         if: ${{ matrix.command == 'test:acceptance' }}
 
       - uses: actions/cache@v4.0.2
         name: Setup Playwright binary cache
+        id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-binary-${{ env.PLAYWRIGHT_VERSION }}
@@ -73,7 +73,7 @@ jobs:
 
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
-        if: ${{ matrix.command == 'test:acceptance' }}
+        if: ${{ matrix.command == 'test:acceptance' && steps.playwright-cache.outputs.cache-hit != 'true' }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
The Cypress binary is only available when the pnpm dependencies cache is not hit, aka when pnpm install actually downloads dependencies. The problem is that a postinstall hook downloads the Cypress binary, which is not triggered when the dependencies are loaded from cache.

The solution is to cache the Cypress binary along with the pnpm dependencies.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [x] Cypress integration tests ensure that login app pages work as expected. The ZITADEL API is mocked.
- [x] No debug or dead code
- [x] My code has no repetitions
