### PR TITLE
Add support for http based instances in middleware

### DIFF
--- a/apps/login/src/middleware.ts
+++ b/apps/login/src/middleware.ts
@@ -23,7 +23,7 @@ export function middleware(request: NextRequest) {
   // this is a workaround for the next.js server not forwarding the host header
   requestHeaders.set(
     "x-zitadel-instance-host",
-    `${INSTANCE}`.replace("https://", ""),
+    `${INSTANCE}`.replace(/^https?:\/\//, ""),
   );
 
   const responseHeaders = new Headers();


### PR DESCRIPTION
It's mostly useful for a local development with login app running on http://localhost:3000

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [ ] Cypress integration tests ensure that login app pages work as expected. The ZITADEL API is mocked.
- [ ] No debug or dead code
- [ ] My code has no repetitions
