### PR TITLE
additional login settings

### DIFF
--- a/apps/login/cypress/integration/login.cy.ts
+++ b/apps/login/cypress/integration/login.cy.ts
@@ -49,6 +49,7 @@ describe("login", () => {
       data: {
         settings: {
           passkeysType: 1,
+          allowUsernamePassword: true,
         },
       },
     });

--- a/apps/login/src/app/(login)/authenticator/set/page.tsx
+++ b/apps/login/src/app/(login)/authenticator/set/page.tsx
@@ -2,12 +2,10 @@ import { Alert } from "@/components/alert";
 import { BackButton } from "@/components/back-button";
 import { ChooseAuthenticatorToSetup } from "@/components/choose-authenticator-to-setup";
 import { DynamicTheme } from "@/components/dynamic-theme";
-import { SignInWithIdp } from "@/components/sign-in-with-idp";
 import { UserAvatar } from "@/components/user-avatar";
 import { getSessionCookieById } from "@/lib/cookies";
 import { loadMostRecentSession } from "@/lib/session";
 import {
-  getActiveIdentityProviders,
   getBrandingSettings,
   getLoginSettings,
   getSession,
@@ -88,11 +86,11 @@ export default async function Page(props: {
     sessionWithData.factors?.user?.organizationId,
   );
 
-  const identityProviders = await getActiveIdentityProviders(
-    sessionWithData.factors?.user?.organizationId,
-  ).then((resp) => {
-    return resp.identityProviders;
-  });
+  //   const identityProviders = await getActiveIdentityProviders(
+  //     sessionWithData.factors?.user?.organizationId,
+  //   ).then((resp) => {
+  //     return resp.identityProviders;
+  //   });
 
   const params = new URLSearchParams({
     initial: "true", // defines that a code is not required and is therefore not shown in the UI
@@ -136,7 +134,7 @@ export default async function Page(props: {
           ></ChooseAuthenticatorToSetup>
         )}
 
-        <p className="ztdl-p text-center">
+        {/* <p className="ztdl-p text-center">
           or sign in with an Identity Provider
         </p>
 
@@ -148,7 +146,7 @@ export default async function Page(props: {
             organization={sessionWithData.factors?.user?.organizationId}
             linkOnly={true} // tell the callback function to just link the IDP and not login, to get an error when user is already available
           ></SignInWithIdp>
-        )}
+        )} */}
 
         <div className="mt-8 flex w-full flex-row items-center">
           <BackButton />

--- a/apps/login/src/app/(login)/authenticator/set/page.tsx
+++ b/apps/login/src/app/(login)/authenticator/set/page.tsx
@@ -2,10 +2,12 @@ import { Alert } from "@/components/alert";
 import { BackButton } from "@/components/back-button";
 import { ChooseAuthenticatorToSetup } from "@/components/choose-authenticator-to-setup";
 import { DynamicTheme } from "@/components/dynamic-theme";
+import { SignInWithIdp } from "@/components/sign-in-with-idp";
 import { UserAvatar } from "@/components/user-avatar";
 import { getSessionCookieById } from "@/lib/cookies";
 import { loadMostRecentSession } from "@/lib/session";
 import {
+  getActiveIdentityProviders,
   getBrandingSettings,
   getLoginSettings,
   getSession,
@@ -74,6 +76,10 @@ export default async function Page(props: {
     });
   }
 
+  if (!sessionWithData) {
+    return <Alert>{tError("unknownContext")}</Alert>;
+  }
+
   const branding = await getBrandingSettings(
     sessionWithData.factors?.user?.organizationId,
   );
@@ -82,21 +88,31 @@ export default async function Page(props: {
     sessionWithData.factors?.user?.organizationId,
   );
 
+  const identityProviders = await getActiveIdentityProviders(
+    sessionWithData.factors?.user?.organizationId,
+  ).then((resp) => {
+    return resp.identityProviders;
+  });
+
   const params = new URLSearchParams({
     initial: "true", // defines that a code is not required and is therefore not shown in the UI
   });
 
-  if (loginName) {
-    params.set("loginName", loginName);
+  if (sessionWithData.factors?.user?.loginName) {
+    params.set("loginName", sessionWithData.factors?.user?.loginName);
   }
 
-  if (organization) {
-    params.set("organization", organization);
+  if (sessionWithData.factors?.user?.organizationId) {
+    params.set("organization", sessionWithData.factors?.user?.organizationId);
   }
 
   if (authRequestId) {
     params.set("authRequestId", authRequestId);
   }
+
+  const host = process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : "http://localhost:3000";
 
   return (
     <DynamicTheme branding={branding}>
@@ -105,23 +121,33 @@ export default async function Page(props: {
 
         <p className="ztdl-p">{t("description")}</p>
 
-        {sessionWithData && (
-          <UserAvatar
-            loginName={loginName ?? sessionWithData.factors?.user?.loginName}
-            displayName={sessionWithData.factors?.user?.displayName}
-            showDropdown
-            searchParams={searchParams}
-          ></UserAvatar>
-        )}
+        <UserAvatar
+          loginName={sessionWithData.factors?.user?.loginName}
+          displayName={sessionWithData.factors?.user?.displayName}
+          showDropdown
+          searchParams={searchParams}
+        ></UserAvatar>
 
-        {!(loginName || sessionId) && <Alert>{tError("unknownContext")}</Alert>}
-
-        {loginSettings && sessionWithData && (
+        {loginSettings && (
           <ChooseAuthenticatorToSetup
             authMethods={sessionWithData.authMethods}
             loginSettings={loginSettings}
             params={params}
           ></ChooseAuthenticatorToSetup>
+        )}
+
+        <p className="ztdl-p text-center">
+          or sign in with an Identity Provider
+        </p>
+
+        {loginSettings?.allowExternalIdp && identityProviders && (
+          <SignInWithIdp
+            host={host}
+            identityProviders={identityProviders}
+            authRequestId={authRequestId}
+            organization={sessionWithData.factors?.user?.organizationId}
+            linkOnly={true} // tell the callback function to just link the IDP and not login, to get an error when user is already available
+          ></SignInWithIdp>
         )}
 
         <div className="mt-8 flex w-full flex-row items-center">

--- a/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
+++ b/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
@@ -37,7 +37,7 @@ export default async function Page(props: {
   const searchParams = await props.searchParams;
   const locale = getLocale();
   const t = await getTranslations({ locale, namespace: "idp" });
-  const { id, token, authRequestId, organization } = searchParams;
+  const { id, token, authRequestId, organization, link } = searchParams;
   const { provider } = params;
 
   const branding = await getBrandingSettings(organization);
@@ -50,7 +50,8 @@ export default async function Page(props: {
 
   const { idpInformation, userId } = intent;
 
-  if (userId) {
+  // sign in user. If user should be linked continue
+  if (userId && !link) {
     // TODO: update user if idp.options.isAutoUpdate is true
 
     return (

--- a/apps/login/src/app/(login)/loginname/page.tsx
+++ b/apps/login/src/app/(login)/loginname/page.tsx
@@ -2,22 +2,13 @@ import { DynamicTheme } from "@/components/dynamic-theme";
 import { SignInWithIdp } from "@/components/sign-in-with-idp";
 import { UsernameForm } from "@/components/username-form";
 import {
+  getActiveIdentityProviders,
   getBrandingSettings,
   getDefaultOrg,
   getLoginSettings,
-  settingsService,
 } from "@/lib/zitadel";
-import { makeReqCtx } from "@zitadel/client/v2";
 import { Organization } from "@zitadel/proto/zitadel/org/v2/org_pb";
 import { getLocale, getTranslations } from "next-intl/server";
-
-function getIdentityProviders(orgId?: string) {
-  return settingsService
-    .getActiveIdentityProviders({ ctx: makeReqCtx(orgId) }, {})
-    .then((resp) => {
-      return resp.identityProviders;
-    });
-}
 
 export default async function Page(props: {
   searchParams: Promise<Record<string | number | symbol, string | undefined>>;
@@ -47,9 +38,11 @@ export default async function Page(props: {
     organization ?? defaultOrganization,
   );
 
-  const identityProviders = await getIdentityProviders(
+  const identityProviders = await getActiveIdentityProviders(
     organization ?? defaultOrganization,
-  );
+  ).then((resp) => {
+    return resp.identityProviders;
+  });
 
   const branding = await getBrandingSettings(
     organization ?? defaultOrganization,
@@ -68,7 +61,7 @@ export default async function Page(props: {
           submit={submit}
           allowRegister={!!loginSettings?.allowRegister}
         >
-          {identityProviders && process.env.ZITADEL_API_URL && (
+          {identityProviders && (
             <SignInWithIdp
               host={host}
               identityProviders={identityProviders}

--- a/apps/login/src/app/(login)/otp/[method]/page.tsx
+++ b/apps/login/src/app/(login)/otp/[method]/page.tsx
@@ -5,6 +5,7 @@ import { UserAvatar } from "@/components/user-avatar";
 import { loadMostRecentSession } from "@/lib/session";
 import { getBrandingSettings, getLoginSettings } from "@/lib/zitadel";
 import { getLocale, getTranslations } from "next-intl/server";
+import { headers } from "next/headers";
 
 export default async function Page(props: {
   searchParams: Promise<Record<string | number | symbol, string | undefined>>;
@@ -29,6 +30,8 @@ export default async function Page(props: {
   const branding = await getBrandingSettings(organization);
 
   const loginSettings = await getLoginSettings(organization);
+
+  const host = (await headers()).get("host");
 
   return (
     <DynamicTheme branding={branding}>
@@ -67,6 +70,8 @@ export default async function Page(props: {
             organization={organization}
             method={method}
             loginSettings={loginSettings}
+            host={host}
+            code={code}
           ></LoginOTP>
         )}
       </div>

--- a/apps/login/src/components/login-otp.tsx
+++ b/apps/login/src/components/login-otp.tsx
@@ -25,6 +25,7 @@ type Props = {
   method: string;
   code?: string;
   loginSettings?: LoginSettings;
+  host: string | null;
 };
 
 type Inputs = {
@@ -39,6 +40,7 @@ export function LoginOTP({
   method,
   code,
   loginSettings,
+  host,
 }: Props) {
   const t = useTranslations("otp");
 
@@ -76,7 +78,18 @@ export function LoginOTP({
 
     if (method === "email") {
       challenges = create(RequestChallengesSchema, {
-        otpEmail: { deliveryType: { case: "sendCode", value: {} } },
+        otpEmail: {
+          deliveryType: {
+            case: "sendCode",
+            value: host
+              ? {
+                  urlTemplate:
+                    `${host.includes("localhost") ? "http://" : "https://"}${host}/otp/method=${method}?code={{.Code}}&userId={{.UserID}}&sessionId={{.SessionID}}&organization={{.OrgID}}` +
+                    (authRequestId ? `&authRequestId=${authRequestId}` : ""),
+                }
+              : {},
+          },
+        },
       });
     }
 

--- a/apps/login/src/components/password-form.tsx
+++ b/apps/login/src/components/password-form.tsx
@@ -86,6 +86,7 @@ export function PasswordForm({
     const response = await resetPassword({
       loginName,
       organization,
+      authRequestId,
     })
       .catch(() => {
         setError("Could not reset password");

--- a/apps/login/src/components/password-form.tsx
+++ b/apps/login/src/components/password-form.tsx
@@ -59,7 +59,6 @@ export function PasswordForm({
         password: { password: values.password },
       }),
       authRequestId,
-      forceMfa: loginSettings?.forceMfa,
     })
       .catch(() => {
         setError("Could not verify password");

--- a/apps/login/src/components/session-item.tsx
+++ b/apps/login/src/components/session-item.tsx
@@ -102,7 +102,7 @@ export function SessionItem({
         />
       </div>
 
-      <div className="flex flex-col overflow-hidden">
+      <div className="flex flex-col items-start overflow-hidden">
         <span className="">{session.factors?.user?.displayName}</span>
         <span className="text-xs opacity-80 text-ellipsis">
           {session.factors?.user?.loginName}

--- a/apps/login/src/components/sign-in-with-idp.tsx
+++ b/apps/login/src/components/sign-in-with-idp.tsx
@@ -22,6 +22,7 @@ export interface SignInWithIDPProps {
   identityProviders: IdentityProvider[];
   authRequestId?: string;
   organization?: string;
+  linkOnly?: boolean;
 }
 
 export function SignInWithIdp({
@@ -29,6 +30,7 @@ export function SignInWithIdp({
   identityProviders,
   authRequestId,
   organization,
+  linkOnly,
 }: SignInWithIDPProps) {
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
@@ -38,6 +40,10 @@ export function SignInWithIdp({
     setLoading(true);
 
     const params = new URLSearchParams();
+
+    if (linkOnly) {
+      params.set("link", "true");
+    }
 
     if (authRequestId) {
       params.set("authRequestId", authRequestId);
@@ -70,121 +76,134 @@ export function SignInWithIdp({
   return (
     <div className="flex flex-col w-full space-y-2 text-sm">
       {identityProviders &&
-        identityProviders.map((idp, i) => {
-          switch (idp.type) {
-            case IdentityProviderType.APPLE:
-              return (
-                <SignInWithApple
-                  key={`idp-${i}`}
-                  name={idp.name}
-                  onClick={() =>
-                    startFlow(idp.id, idpTypeToSlug(IdentityProviderType.APPLE))
-                  }
-                ></SignInWithApple>
-              );
-            case IdentityProviderType.OAUTH:
-              return (
-                <SignInWithGeneric
-                  key={`idp-${i}`}
-                  name={idp.name}
-                  onClick={() =>
-                    startFlow(idp.id, idpTypeToSlug(IdentityProviderType.OAUTH))
-                  }
-                ></SignInWithGeneric>
-              );
-            case IdentityProviderType.OIDC:
-              return (
-                <SignInWithGeneric
-                  key={`idp-${i}`}
-                  name={idp.name}
-                  onClick={() =>
-                    startFlow(idp.id, idpTypeToSlug(IdentityProviderType.OIDC))
-                  }
-                ></SignInWithGeneric>
-              );
-            case IdentityProviderType.GITHUB:
-              return (
-                <SignInWithGithub
-                  key={`idp-${i}`}
-                  name={idp.name}
-                  onClick={() =>
-                    startFlow(
-                      idp.id,
-                      idpTypeToSlug(IdentityProviderType.GITHUB),
-                    )
-                  }
-                ></SignInWithGithub>
-              );
-            case IdentityProviderType.GITHUB_ES:
-              return (
-                <SignInWithGithub
-                  key={`idp-${i}`}
-                  name={idp.name}
-                  onClick={() =>
-                    startFlow(
-                      idp.id,
-                      idpTypeToSlug(IdentityProviderType.GITHUB_ES),
-                    )
-                  }
-                ></SignInWithGithub>
-              );
-            case IdentityProviderType.AZURE_AD:
-              return (
-                <SignInWithAzureAd
-                  key={`idp-${i}`}
-                  name={idp.name}
-                  onClick={() =>
-                    startFlow(
-                      idp.id,
-                      idpTypeToSlug(IdentityProviderType.AZURE_AD),
-                    )
-                  }
-                ></SignInWithAzureAd>
-              );
-            case IdentityProviderType.GOOGLE:
-              return (
-                <SignInWithGoogle
-                  key={`idp-${i}`}
-                  e2e="google"
-                  name={idp.name}
-                  onClick={() =>
-                    startFlow(
-                      idp.id,
-                      idpTypeToSlug(IdentityProviderType.GOOGLE),
-                    )
-                  }
-                ></SignInWithGoogle>
-              );
-            case IdentityProviderType.GITLAB:
-              return (
-                <SignInWithGitlab
-                  key={`idp-${i}`}
-                  name={idp.name}
-                  onClick={() =>
-                    startFlow(
-                      idp.id,
-                      idpTypeToSlug(IdentityProviderType.GITLAB),
-                    )
-                  }
-                ></SignInWithGitlab>
-              );
-            case IdentityProviderType.GITLAB_SELF_HOSTED:
-              return (
-                <SignInWithGitlab
-                  key={`idp-${i}`}
-                  name={idp.name}
-                  onClick={() =>
-                    startFlow(
-                      idp.id,
-                      idpTypeToSlug(IdentityProviderType.GITLAB_SELF_HOSTED),
-                    )
-                  }
-                ></SignInWithGitlab>
-              );
-            default:
-              return null;
-          }
-        })}
+        identityProviders
+          //   .filter((idp) =>
+          //     linkOnly ? idp.config?.options.isLinkingAllowed : true,
+          //   )
+          .map((idp, i) => {
+            switch (idp.type) {
+              case IdentityProviderType.APPLE:
+                return (
+                  <SignInWithApple
+                    key={`idp-${i}`}
+                    name={idp.name}
+                    onClick={() =>
+                      startFlow(
+                        idp.id,
+                        idpTypeToSlug(IdentityProviderType.APPLE),
+                      )
+                    }
+                  ></SignInWithApple>
+                );
+              case IdentityProviderType.OAUTH:
+                return (
+                  <SignInWithGeneric
+                    key={`idp-${i}`}
+                    name={idp.name}
+                    onClick={() =>
+                      startFlow(
+                        idp.id,
+                        idpTypeToSlug(IdentityProviderType.OAUTH),
+                      )
+                    }
+                  ></SignInWithGeneric>
+                );
+              case IdentityProviderType.OIDC:
+                return (
+                  <SignInWithGeneric
+                    key={`idp-${i}`}
+                    name={idp.name}
+                    onClick={() =>
+                      startFlow(
+                        idp.id,
+                        idpTypeToSlug(IdentityProviderType.OIDC),
+                      )
+                    }
+                  ></SignInWithGeneric>
+                );
+              case IdentityProviderType.GITHUB:
+                return (
+                  <SignInWithGithub
+                    key={`idp-${i}`}
+                    name={idp.name}
+                    onClick={() =>
+                      startFlow(
+                        idp.id,
+                        idpTypeToSlug(IdentityProviderType.GITHUB),
+                      )
+                    }
+                  ></SignInWithGithub>
+                );
+              case IdentityProviderType.GITHUB_ES:
+                return (
+                  <SignInWithGithub
+                    key={`idp-${i}`}
+                    name={idp.name}
+                    onClick={() =>
+                      startFlow(
+                        idp.id,
+                        idpTypeToSlug(IdentityProviderType.GITHUB_ES),
+                      )
+                    }
+                  ></SignInWithGithub>
+                );
+              case IdentityProviderType.AZURE_AD:
+                return (
+                  <SignInWithAzureAd
+                    key={`idp-${i}`}
+                    name={idp.name}
+                    onClick={() =>
+                      startFlow(
+                        idp.id,
+                        idpTypeToSlug(IdentityProviderType.AZURE_AD),
+                      )
+                    }
+                  ></SignInWithAzureAd>
+                );
+              case IdentityProviderType.GOOGLE:
+                return (
+                  <SignInWithGoogle
+                    key={`idp-${i}`}
+                    e2e="google"
+                    name={idp.name}
+                    onClick={() =>
+                      startFlow(
+                        idp.id,
+                        idpTypeToSlug(IdentityProviderType.GOOGLE),
+                      )
+                    }
+                  ></SignInWithGoogle>
+                );
+              case IdentityProviderType.GITLAB:
+                return (
+                  <SignInWithGitlab
+                    key={`idp-${i}`}
+                    name={idp.name}
+                    onClick={() =>
+                      startFlow(
+                        idp.id,
+                        idpTypeToSlug(IdentityProviderType.GITLAB),
+                      )
+                    }
+                  ></SignInWithGitlab>
+                );
+              case IdentityProviderType.GITLAB_SELF_HOSTED:
+                return (
+                  <SignInWithGitlab
+                    key={`idp-${i}`}
+                    name={idp.name}
+                    onClick={() =>
+                      startFlow(
+                        idp.id,
+                        idpTypeToSlug(IdentityProviderType.GITLAB_SELF_HOSTED),
+                      )
+                    }
+                  ></SignInWithGitlab>
+                );
+              default:
+                return null;
+            }
+          })}
       {error && (
         <div className="py-4">
           <Alert>{error}</Alert>

--- a/apps/login/src/components/username-form.tsx
+++ b/apps/login/src/components/username-form.tsx
@@ -61,6 +61,8 @@ export function UsernameForm({
         setLoading(false);
       });
 
+    console.log(res, "res");
+
     if (res?.redirect) {
       return router.push(res.redirect);
     }

--- a/apps/login/src/lib/client.ts
+++ b/apps/login/src/lib/client.ts
@@ -15,24 +15,29 @@ export async function getNextUrl(
   defaultRedirectUri?: string,
 ): Promise<string> {
   if ("sessionId" in command && "authRequestId" in command) {
-    const url =
-      `/login?` +
-      new URLSearchParams({
-        sessionId: command.sessionId,
-        authRequest: command.authRequestId,
-      });
-    return url;
+    const params = new URLSearchParams({
+      sessionId: command.sessionId,
+      authRequest: command.authRequestId,
+    });
+
+    if (command.organization) {
+      params.append("organization", command.organization);
+    }
+
+    return `/login?` + params;
   }
 
   if (defaultRedirectUri) {
     return defaultRedirectUri;
   }
 
-  const signedInUrl =
-    `/signedin?` +
-    new URLSearchParams({
-      loginName: command.loginName,
-    });
+  const params = new URLSearchParams({
+    loginName: command.loginName,
+  });
 
-  return signedInUrl;
+  if (command.organization) {
+    params.append("organization", command.organization);
+  }
+
+  return `/signedin?` + params;
 }

--- a/apps/login/src/lib/server/loginname.ts
+++ b/apps/login/src/lib/server/loginname.ts
@@ -2,7 +2,6 @@
 
 import { create } from "@zitadel/client";
 import { ChecksSchema } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
-import { UserState } from "@zitadel/proto/zitadel/user/v2/user_pb";
 import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 import { headers } from "next/headers";
 import { idpTypeToIdentityProviderType, idpTypeToSlug } from "../idp";
@@ -136,25 +135,29 @@ export async function sendLoginname(command: SendLoginnameCommand) {
       return { error: "Could not create session for user" };
     }
 
-    if (users.result[0].state === UserState.INITIAL) {
-      const params = new URLSearchParams({
-        loginName: session.factors?.user?.loginName,
-        initial: "true", // this does not require a code to be set
-      });
+    // TODO: check if handling of userstate INITIAL is needed
 
-      if (command.organization || session.factors?.user?.organizationId) {
-        params.append(
-          "organization",
-          command.organization ?? session.factors?.user?.organizationId,
-        );
-      }
+    // if (
+    //   users.result[0].state === UserState.INITIAL
+    // ) {
+    //   const params = new URLSearchParams({
+    //     loginName: session.factors?.user?.loginName,
+    //     initial: "true", // this does not require a code to be set
+    //   });
 
-      if (command.authRequestId) {
-        params.append("authRequestid", command.authRequestId);
-      }
+    //   if (command.organization || session.factors?.user?.organizationId) {
+    //     params.append(
+    //       "organization",
+    //       command.organization ?? session.factors?.user?.organizationId,
+    //     );
+    //   }
 
-      return { redirect: "/password/set?" + params };
-    }
+    //   if (command.authRequestId) {
+    //     params.append("authRequestId", command.authRequestId);
+    //   }
+
+    //   return { redirect: "/password/set?" + params };
+    // }
 
     const methods = await listAuthenticationMethodTypes(
       session.factors?.user?.id,

--- a/apps/login/src/lib/server/loginname.ts
+++ b/apps/login/src/lib/server/loginname.ts
@@ -94,6 +94,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
       const identityProviderId = identityProviders[0].idpId;
 
       const idp = await getIDPByID(identityProviderId);
+
       const idpType = idp?.type;
 
       if (!idp || !idpType) {
@@ -271,7 +272,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
       } else if (
         methods.authMethodTypes.includes(AuthenticationMethodType.IDP)
       ) {
-        await redirectUserToIDP(userId);
+        return redirectUserToIDP(userId);
       } else if (
         methods.authMethodTypes.includes(AuthenticationMethodType.PASSWORD)
       ) {
@@ -297,8 +298,10 @@ export async function sendLoginname(command: SendLoginnameCommand) {
   // user not found, check if register is enabled on organization
   if (loginSettings?.allowRegister && !loginSettings?.allowUsernamePassword) {
     // TODO: do we need to handle login hints for IDPs here?
-    await redirectUserToSingleIDPIfAvailable();
-
+    const resp = await redirectUserToSingleIDPIfAvailable();
+    if (resp) {
+      return resp;
+    }
     return { error: "Could not find user" };
   } else if (
     loginSettings?.allowRegister &&

--- a/apps/login/src/lib/server/password.ts
+++ b/apps/login/src/lib/server/password.ts
@@ -54,7 +54,6 @@ export type UpdateSessionCommand = {
   organization?: string;
   checks: Checks;
   authRequestId?: string;
-  forceMfa?: boolean;
 };
 
 export async function sendPassword(command: UpdateSessionCommand) {
@@ -209,7 +208,10 @@ export async function sendPassword(command: UpdateSessionCommand) {
     }
 
     return { redirect: `/password/change?` + params };
-  } else if (command.forceMfa && !availableSecondFactors.length) {
+  } else if (
+    (loginSettings?.forceMfa || loginSettings?.forceMfaLocalOnly) &&
+    !availableSecondFactors.length
+  ) {
     const params = new URLSearchParams({
       loginName: session.factors.user.loginName,
       force: "true", // this defines if the mfa is forced in the settings

--- a/apps/login/src/lib/server/password.ts
+++ b/apps/login/src/lib/server/password.ts
@@ -149,6 +149,7 @@ export async function sendPassword(command: UpdateSessionCommand) {
   );
 
   const humanUser = user.type.case === "human" ? user.type.value : undefined;
+  console.log("humanUser", humanUser);
   if (
     availableSecondFactors?.length == 0 &&
     humanUser?.passwordChangeRequired

--- a/apps/login/src/lib/server/password.ts
+++ b/apps/login/src/lib/server/password.ts
@@ -27,6 +27,7 @@ import { getSessionCookieByLoginName } from "../cookies";
 type ResetPasswordCommand = {
   loginName: string;
   organization?: string;
+  authRequestId?: string;
 };
 
 export async function resetPassword(command: ResetPasswordCommand) {
@@ -46,7 +47,7 @@ export async function resetPassword(command: ResetPasswordCommand) {
   }
   const userId = users.result[0].userId;
 
-  return passwordReset(userId, host);
+  return passwordReset(userId, host, command.authRequestId);
 }
 
 export type UpdateSessionCommand = {

--- a/apps/login/src/lib/server/password.ts
+++ b/apps/login/src/lib/server/password.ts
@@ -18,7 +18,7 @@ import {
   ChecksSchema,
 } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
 import { LoginSettings } from "@zitadel/proto/zitadel/settings/v2/login_settings_pb";
-import { User } from "@zitadel/proto/zitadel/user/v2/user_pb";
+import { User, UserState } from "@zitadel/proto/zitadel/user/v2/user_pb";
 import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 import { headers } from "next/headers";
 import { getNextUrl } from "../client";
@@ -215,26 +215,9 @@ export async function sendPassword(command: UpdateSessionCommand) {
     return { redirect: `/mfa?` + params };
   }
   // TODO: check if handling of userstate INITIAL is needed
-
-  //    else if (user.state === UserState.INITIAL) {
-  //     const params = new URLSearchParams({
-  //       loginName: session.factors.user.loginName,
-  //     });
-
-  //     if (command.authRequestId) {
-  //       params.append("authRequestId", command.authRequestId);
-  //     }
-
-  //     if (command.organization || session.factors?.user?.organizationId) {
-  //       params.append(
-  //         "organization",
-  //         command.organization ?? session.factors?.user?.organizationId,
-  //       );
-  //     }
-
-  //     return { redirect: `/password/change?` + params };
-  //   }
-  else if (
+  else if (user.state === UserState.INITIAL) {
+    return { error: "Initial User not supported" };
+  } else if (
     (loginSettings?.forceMfa || loginSettings?.forceMfaLocalOnly) &&
     !availableSecondFactors.length
   ) {

--- a/apps/login/src/lib/zitadel.ts
+++ b/apps/login/src/lib/zitadel.ts
@@ -504,7 +504,11 @@ export function createUser(
  * @param userId the id of the user where the email should be set
  * @returns the newly set email
  */
-export async function passwordReset(userId: string, host: string | null) {
+export async function passwordReset(
+  userId: string,
+  host: string | null,
+  authRequestId?: string,
+) {
   let medium = create(SendPasswordResetLinkSchema, {
     notificationType: NotificationType.Email,
   });
@@ -512,7 +516,9 @@ export async function passwordReset(userId: string, host: string | null) {
   if (host) {
     medium = {
       ...medium,
-      urlTemplate: `${host.includes("localhost") ? "http://" : "https://"}${host}/password/set?code={{.Code}}&userId={{.UserID}}&organization={{.OrgID}}`,
+      urlTemplate:
+        `${host.includes("localhost") ? "http://" : "https://"}${host}/password/set?code={{.Code}}&userId={{.UserID}}&organization={{.OrgID}}` +
+        (authRequestId ? `&authRequestId=${authRequestId}` : ""),
     };
   }
 


### PR DESCRIPTION
These features / fixes are implemented with this PR

- password change required is handled now. after a user password is checked, and if change is required, a user will be redirected to `/password/change`
- an additional check for force MFA is done, after checking a user password. If either forceMFA or forceLocalMFA is enforced, a user is prompted to setup MFA after password verification
- a password reset link now includes the authRequest if the flow was initiated with it 
- OTP links redirect to the same host where the flow was initiated and include the authRequest
- A user invitation can now be linked to an IDP
- if phone / email login is disabled, user results are removed where the input equals the disabled method
- If passkeys / password is disabled, throw an error.
- Check user initial state compatibility. We check for `passwordChangeRequired` but a user may still be initial state. This prevents the password change -> check migration path
- [ ] Add IDPs to invite user flow 

- TODO: https://github.com/zitadel/zitadel/issues/8981 

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [ ] Cypress integration tests ensure that login app pages work as expected. The ZITADEL API is mocked.
- [ ] No debug or dead code
- [ ] My code has no repetitions
