### PR TITLE
Promote qa to prod

### DIFF
--- a/apps/login/readme.md
+++ b/apps/login/readme.md
@@ -389,7 +389,8 @@ In future, self service options to jump to are shown below, like:
 
 ## Currently NOT Supported
 
-- loginSettings.disableLoginWithEmail
-- loginSettings.disableLoginWithPhone
-- loginSettings.allowExternalIdp - this will be deprecated with the new login as it can be determined by the available IDPs
-- loginSettings.forceMfaLocalOnly
+Timebased features like the multifactor init prompt or password expiry, are not supported due to a current limitation in the API. Lockout settings which keeps track of the password retries, will also be implemented in a later stage.
+
+- Lockout Settings
+- Password Expiry Settings
+- Login Settings: multifactor init prompt

--- a/apps/login/src/app/(login)/authenticator/set/page.tsx
+++ b/apps/login/src/app/(login)/authenticator/set/page.tsx
@@ -110,6 +110,10 @@ export default async function Page(props: {
     params.set("authRequestId", authRequestId);
   }
 
+  const host = process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : "http://localhost:3000";
+
   return (
     <DynamicTheme branding={branding}>
       <div className="flex flex-col items-center space-y-4">

--- a/apps/login/src/app/(login)/authenticator/set/page.tsx
+++ b/apps/login/src/app/(login)/authenticator/set/page.tsx
@@ -110,10 +110,6 @@ export default async function Page(props: {
     params.set("authRequestId", authRequestId);
   }
 
-  const host = process.env.VERCEL_URL
-    ? `https://${process.env.VERCEL_URL}`
-    : "http://localhost:3000";
-
   return (
     <DynamicTheme branding={branding}>
       <div className="flex flex-col items-center space-y-4">

--- a/apps/login/src/app/(login)/authenticator/set/page.tsx
+++ b/apps/login/src/app/(login)/authenticator/set/page.tsx
@@ -86,6 +86,8 @@ export default async function Page(props: {
     sessionWithData.factors?.user?.organizationId,
   );
 
+  /* - TODO: Implement after https://github.com/zitadel/zitadel/issues/8981  */
+
   //   const identityProviders = await getActiveIdentityProviders(
   //     sessionWithData.factors?.user?.organizationId,
   //   ).then((resp) => {
@@ -133,6 +135,8 @@ export default async function Page(props: {
             params={params}
           ></ChooseAuthenticatorToSetup>
         )}
+
+        {/* - TODO: Implement after https://github.com/zitadel/zitadel/issues/8981  */}
 
         {/* <p className="ztdl-p text-center">
           or sign in with an Identity Provider

--- a/apps/login/src/app/(login)/idp/page.tsx
+++ b/apps/login/src/app/(login)/idp/page.tsx
@@ -24,10 +24,6 @@ export default async function Page(props: {
 
   const identityProviders = await getIdentityProviders(organization);
 
-  const host = process.env.VERCEL_URL
-    ? `https://${process.env.VERCEL_URL}`
-    : "http://localhost:3000";
-
   const branding = await getBrandingSettings(organization);
 
   return (
@@ -38,7 +34,6 @@ export default async function Page(props: {
 
         {identityProviders && (
           <SignInWithIdp
-            host={host}
             identityProviders={identityProviders}
             authRequestId={authRequestId}
             organization={organization}

--- a/apps/login/src/app/(login)/loginname/page.tsx
+++ b/apps/login/src/app/(login)/loginname/page.tsx
@@ -30,10 +30,6 @@ export default async function Page(props: {
     }
   }
 
-  const host = process.env.VERCEL_URL
-    ? `https://${process.env.VERCEL_URL}`
-    : "http://localhost:3000";
-
   const loginSettings = await getLoginSettings(
     organization ?? defaultOrganization,
   );
@@ -63,7 +59,6 @@ export default async function Page(props: {
         >
           {identityProviders && (
             <SignInWithIdp
-              host={host}
               identityProviders={identityProviders}
               authRequestId={authRequestId}
               organization={organization ?? defaultOrganization} // use the organization from the searchParams here otherwise fallback to the default organization

--- a/apps/login/src/app/(login)/otp/[method]/page.tsx
+++ b/apps/login/src/app/(login)/otp/[method]/page.tsx
@@ -31,7 +31,7 @@ export default async function Page(props: {
 
   const loginSettings = await getLoginSettings(organization);
 
-  const origin = (await headers()).get("origin");
+  const host = (await headers()).get("host");
 
   return (
     <DynamicTheme branding={branding}>
@@ -70,7 +70,7 @@ export default async function Page(props: {
             organization={organization}
             method={method}
             loginSettings={loginSettings}
-            origin={origin}
+            host={host}
             code={code}
           ></LoginOTP>
         )}

--- a/apps/login/src/app/(login)/otp/[method]/page.tsx
+++ b/apps/login/src/app/(login)/otp/[method]/page.tsx
@@ -31,7 +31,7 @@ export default async function Page(props: {
 
   const loginSettings = await getLoginSettings(organization);
 
-  const host = (await headers()).get("host");
+  const origin = (await headers()).get("origin");
 
   return (
     <DynamicTheme branding={branding}>
@@ -70,7 +70,7 @@ export default async function Page(props: {
             organization={organization}
             method={method}
             loginSettings={loginSettings}
-            host={host}
+            origin={origin}
             code={code}
           ></LoginOTP>
         )}

--- a/apps/login/src/app/login/route.ts
+++ b/apps/login/src/app/login/route.ts
@@ -174,7 +174,7 @@ export async function GET(request: NextRequest) {
         const idp = identityProviders.find((idp) => idp.id === idpId);
 
         if (idp) {
-          const host = request.nextUrl.origin;
+          const origin = request.nextUrl.origin;
 
           const identityProviderType = identityProviders[0].type;
           let provider = idpTypeToSlug(identityProviderType);
@@ -193,10 +193,10 @@ export async function GET(request: NextRequest) {
             idpId,
             urls: {
               successUrl:
-                `${host}/idp/${provider}/success?` +
+                `${origin}/idp/${provider}/success?` +
                 new URLSearchParams(params),
               failureUrl:
-                `${host}/idp/${provider}/failure?` +
+                `${origin}/idp/${provider}/failure?` +
                 new URLSearchParams(params),
             },
           }).then((resp) => {

--- a/apps/login/src/components/login-otp.tsx
+++ b/apps/login/src/components/login-otp.tsx
@@ -25,7 +25,7 @@ type Props = {
   method: string;
   code?: string;
   loginSettings?: LoginSettings;
-  origin: string | null;
+  host: string | null;
 };
 
 type Inputs = {
@@ -40,7 +40,7 @@ export function LoginOTP({
   method,
   code,
   loginSettings,
-  origin,
+  host,
 }: Props) {
   const t = useTranslations("otp");
 
@@ -81,10 +81,10 @@ export function LoginOTP({
         otpEmail: {
           deliveryType: {
             case: "sendCode",
-            value: origin
+            value: host
               ? {
                   urlTemplate:
-                    `${origin}/otp/method=${method}?code={{.Code}}&userId={{.UserID}}&sessionId={{.SessionID}}&organization={{.OrgID}}` +
+                    `${host.includes("localhost") ? "http://" : "https://"}${host}/otp/method=${method}?code={{.Code}}&userId={{.UserID}}&sessionId={{.SessionID}}&organization={{.OrgID}}` +
                     (authRequestId ? `&authRequestId=${authRequestId}` : ""),
                 }
               : {},

--- a/apps/login/src/components/login-otp.tsx
+++ b/apps/login/src/components/login-otp.tsx
@@ -25,7 +25,7 @@ type Props = {
   method: string;
   code?: string;
   loginSettings?: LoginSettings;
-  host: string | null;
+  origin: string | null;
 };
 
 type Inputs = {
@@ -40,7 +40,7 @@ export function LoginOTP({
   method,
   code,
   loginSettings,
-  host,
+  origin,
 }: Props) {
   const t = useTranslations("otp");
 
@@ -81,10 +81,10 @@ export function LoginOTP({
         otpEmail: {
           deliveryType: {
             case: "sendCode",
-            value: host
+            value: origin
               ? {
                   urlTemplate:
-                    `${host.includes("localhost") ? "http://" : "https://"}${host}/otp/method=${method}?code={{.Code}}&userId={{.UserID}}&sessionId={{.SessionID}}&organization={{.OrgID}}` +
+                    `${origin}/otp/method=${method}?code={{.Code}}&userId={{.UserID}}&sessionId={{.SessionID}}&organization={{.OrgID}}` +
                     (authRequestId ? `&authRequestId=${authRequestId}` : ""),
                 }
               : {},

--- a/apps/login/src/components/session-item.tsx
+++ b/apps/login/src/components/session-item.tsx
@@ -16,12 +16,14 @@ export function isSessionValid(session: Partial<Session>): {
 } {
   const validPassword = session?.factors?.password?.verifiedAt;
   const validPasskey = session?.factors?.webAuthN?.verifiedAt;
+  const validIDP = session?.factors?.intent?.verifiedAt;
+
   const stillValid = session.expirationDate
     ? timestampDate(session.expirationDate) > new Date()
     : true;
 
-  const verifiedAt = validPassword || validPasskey;
-  const valid = !!((validPassword || validPasskey) && stillValid);
+  const verifiedAt = validPassword || validPasskey || validIDP;
+  const valid = !!((validPassword || validPasskey || validIDP) && stillValid);
 
   return { valid, verifiedAt };
 }
@@ -107,9 +109,15 @@ export function SessionItem({
         <span className="text-xs opacity-80 text-ellipsis">
           {session.factors?.user?.loginName}
         </span>
-        {valid && (
+        {valid ? (
           <span className="text-xs opacity-80 text-ellipsis">
             {verifiedAt && moment(timestampDate(verifiedAt)).fromNow()}
+          </span>
+        ) : (
+          <span className="text-xs opacity-80 text-ellipsis">
+            expired{" "}
+            {session.expirationDate &&
+              moment(timestampDate(session.expirationDate)).fromNow()}
           </span>
         )}
       </div>

--- a/apps/login/src/components/sign-in-with-idp.tsx
+++ b/apps/login/src/components/sign-in-with-idp.tsx
@@ -64,6 +64,11 @@ export function SignInWithIdp({
         setLoading(false);
       });
 
+    if (response && "error" in response && response?.error) {
+      setError(response.error);
+      return;
+    }
+
     if (response && "redirect" in response && response?.redirect) {
       return router.push(response.redirect);
     }

--- a/apps/login/src/components/sign-in-with-idp.tsx
+++ b/apps/login/src/components/sign-in-with-idp.tsx
@@ -78,6 +78,8 @@ export function SignInWithIdp({
     <div className="flex flex-col w-full space-y-2 text-sm">
       {identityProviders &&
         identityProviders
+          /* - TODO: Implement after https://github.com/zitadel/zitadel/issues/8981  */
+
           //   .filter((idp) =>
           //     linkOnly ? idp.config?.options.isLinkingAllowed : true,
           //   )

--- a/apps/login/src/components/sign-in-with-idp.tsx
+++ b/apps/login/src/components/sign-in-with-idp.tsx
@@ -6,6 +6,7 @@ import {
   IdentityProvider,
   IdentityProviderType,
 } from "@zitadel/proto/zitadel/settings/v2/login_settings_pb";
+import { headers } from "next/headers";
 import { useRouter } from "next/navigation";
 import { ReactNode, useState } from "react";
 import { Alert } from "./alert";
@@ -18,7 +19,6 @@ import { SignInWithGoogle } from "./idps/sign-in-with-google";
 
 export interface SignInWithIDPProps {
   children?: ReactNode;
-  host: string;
   identityProviders: IdentityProvider[];
   authRequestId?: string;
   organization?: string;
@@ -26,7 +26,6 @@ export interface SignInWithIDPProps {
 }
 
 export function SignInWithIdp({
-  host,
   identityProviders,
   authRequestId,
   organization,
@@ -52,6 +51,8 @@ export function SignInWithIdp({
     if (organization) {
       params.set("organization", organization);
     }
+
+    const host = (await headers()).get("host");
 
     const response = await startIDPFlow({
       idpId,

--- a/apps/login/src/components/sign-in-with-idp.tsx
+++ b/apps/login/src/components/sign-in-with-idp.tsx
@@ -6,7 +6,6 @@ import {
   IdentityProvider,
   IdentityProviderType,
 } from "@zitadel/proto/zitadel/settings/v2/login_settings_pb";
-import { headers } from "next/headers";
 import { useRouter } from "next/navigation";
 import { ReactNode, useState } from "react";
 import { Alert } from "./alert";
@@ -52,14 +51,10 @@ export function SignInWithIdp({
       params.set("organization", organization);
     }
 
-    const host = (await headers()).get("host");
-
     const response = await startIDPFlow({
       idpId,
-      successUrl:
-        `${host}/idp/${provider}/success?` + new URLSearchParams(params),
-      failureUrl:
-        `${host}/idp/${provider}/failure?` + new URLSearchParams(params),
+      successUrl: `/idp/${provider}/success?` + new URLSearchParams(params),
+      failureUrl: `/idp/${provider}/failure?` + new URLSearchParams(params),
     })
       .catch(() => {
         setError("Could not start IDP flow");

--- a/apps/login/src/components/username-form.tsx
+++ b/apps/login/src/components/username-form.tsx
@@ -61,8 +61,6 @@ export function UsernameForm({
         setLoading(false);
       });
 
-    console.log(res, "res");
-
     if (res?.redirect) {
       return router.push(res.redirect);
     }

--- a/apps/login/src/lib/server/idp.ts
+++ b/apps/login/src/lib/server/idp.ts
@@ -10,17 +10,17 @@ export type StartIDPFlowCommand = {
 };
 
 export async function startIDPFlow(command: StartIDPFlowCommand) {
-  const host = (await headers()).get("host");
+  const origin = (await headers()).get("origin");
 
-  if (!host) {
-    return { error: "Could not get host" };
+  if (!origin) {
+    return { error: "Could not get origin" };
   }
 
   return startIdentityProviderFlow({
     idpId: command.idpId,
     urls: {
-      successUrl: `${host.includes("localhost") ? "http://" : "https://"}${host}${command.successUrl}`,
-      failureUrl: `${host.includes("localhost") ? "http://" : "https://"}${host}${command.failureUrl}`,
+      successUrl: `${origin}${command.successUrl}`,
+      failureUrl: `${origin}${command.failureUrl}`,
     },
   }).then((response) => {
     if (

--- a/apps/login/src/lib/server/idp.ts
+++ b/apps/login/src/lib/server/idp.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { startIdentityProviderFlow } from "@/lib/zitadel";
+import { headers } from "next/headers";
 
 export type StartIDPFlowCommand = {
   idpId: string;
@@ -9,11 +10,13 @@ export type StartIDPFlowCommand = {
 };
 
 export async function startIDPFlow(command: StartIDPFlowCommand) {
+  const host = (await headers()).get("host");
+
   return startIdentityProviderFlow({
     idpId: command.idpId,
     urls: {
-      successUrl: command.successUrl,
-      failureUrl: command.failureUrl,
+      successUrl: `${host}${command.successUrl}`,
+      failureUrl: `${host}${command.failureUrl}`,
     },
   }).then((response) => {
     if (

--- a/apps/login/src/lib/server/idp.ts
+++ b/apps/login/src/lib/server/idp.ts
@@ -10,17 +10,17 @@ export type StartIDPFlowCommand = {
 };
 
 export async function startIDPFlow(command: StartIDPFlowCommand) {
-  const origin = (await headers()).get("origin");
+  const host = (await headers()).get("host");
 
-  if (!origin) {
-    return { error: "Could not get origin" };
+  if (!host) {
+    return { error: "Could not get host" };
   }
 
   return startIdentityProviderFlow({
     idpId: command.idpId,
     urls: {
-      successUrl: `${origin}${command.successUrl}`,
-      failureUrl: `${origin}${command.failureUrl}`,
+      successUrl: `${host.includes("localhost") ? "http://" : "https://"}${host}${command.successUrl}`,
+      failureUrl: `${host.includes("localhost") ? "http://" : "https://"}${host}${command.failureUrl}`,
     },
   }).then((response) => {
     if (

--- a/apps/login/src/lib/server/idp.ts
+++ b/apps/login/src/lib/server/idp.ts
@@ -12,11 +12,15 @@ export type StartIDPFlowCommand = {
 export async function startIDPFlow(command: StartIDPFlowCommand) {
   const host = (await headers()).get("host");
 
+  if (!host) {
+    return { error: "Could not get host" };
+  }
+
   return startIdentityProviderFlow({
     idpId: command.idpId,
     urls: {
-      successUrl: `${host}${command.successUrl}`,
-      failureUrl: `${host}${command.failureUrl}`,
+      successUrl: `${host.includes("localhost") ? "http://" : "https://"}${host}${command.successUrl}`,
+      failureUrl: `${host.includes("localhost") ? "http://" : "https://"}${host}${command.failureUrl}`,
     },
   }).then((response) => {
     if (

--- a/apps/login/src/lib/server/invite.ts
+++ b/apps/login/src/lib/server/invite.ts
@@ -20,7 +20,7 @@ export type RegisterUserResponse = {
 };
 
 export async function inviteUser(command: InviteUserCommand) {
-  const origin = (await headers()).get("origin");
+  const host = (await headers()).get("host");
 
   const human = await addHumanUser({
     email: command.email,
@@ -34,7 +34,7 @@ export async function inviteUser(command: InviteUserCommand) {
     return { error: "Could not create user" };
   }
 
-  const codeResponse = await createInviteCode(human.userId, origin);
+  const codeResponse = await createInviteCode(human.userId, host);
 
   if (!codeResponse || !human) {
     return { error: "Could not create invite code" };

--- a/apps/login/src/lib/server/invite.ts
+++ b/apps/login/src/lib/server/invite.ts
@@ -20,7 +20,7 @@ export type RegisterUserResponse = {
 };
 
 export async function inviteUser(command: InviteUserCommand) {
-  const host = (await headers()).get("host");
+  const origin = (await headers()).get("origin");
 
   const human = await addHumanUser({
     email: command.email,
@@ -34,7 +34,7 @@ export async function inviteUser(command: InviteUserCommand) {
     return { error: "Could not create user" };
   }
 
-  const codeResponse = await createInviteCode(human.userId, host);
+  const codeResponse = await createInviteCode(human.userId, origin);
 
   if (!codeResponse || !human) {
     return { error: "Could not create invite code" };

--- a/apps/login/src/lib/server/loginname.ts
+++ b/apps/login/src/lib/server/loginname.ts
@@ -54,6 +54,11 @@ export async function sendLoginname(command: SendLoginnameCommand) {
 
     if (identityProviders.length === 1) {
       const host = (await headers()).get("host");
+
+      if (!host) {
+        return { error: "Could not get host" };
+      }
+
       const identityProviderType = identityProviders[0].type;
 
       const provider = idpTypeToSlug(identityProviderType);
@@ -72,9 +77,11 @@ export async function sendLoginname(command: SendLoginnameCommand) {
         idpId: identityProviders[0].id,
         urls: {
           successUrl:
-            `${host}/idp/${provider}/success?` + new URLSearchParams(params),
+            `${host.includes("localhost") ? "http://" : "https://"}${host}/idp/${provider}/success?` +
+            new URLSearchParams(params),
           failureUrl:
-            `${host}/idp/${provider}/failure?` + new URLSearchParams(params),
+            `${host.includes("localhost") ? "http://" : "https://"}${host}/idp/${provider}/failure?` +
+            new URLSearchParams(params),
         },
       });
 
@@ -91,6 +98,11 @@ export async function sendLoginname(command: SendLoginnameCommand) {
 
     if (identityProviders.length === 1) {
       const host = (await headers()).get("host");
+
+      if (!host) {
+        return { error: "Could not get host" };
+      }
+
       const identityProviderId = identityProviders[0].idpId;
 
       const idp = await getIDPByID(identityProviderId);
@@ -118,9 +130,11 @@ export async function sendLoginname(command: SendLoginnameCommand) {
         idpId: idp.id,
         urls: {
           successUrl:
-            `${host}/idp/${provider}/success?` + new URLSearchParams(params),
+            `${host.includes("localhost") ? "http://" : "https://"}${host}/idp/${provider}/success?` +
+            new URLSearchParams(params),
           failureUrl:
-            `${host}/idp/${provider}/failure?` + new URLSearchParams(params),
+            `${host.includes("localhost") ? "http://" : "https://"}${host}/idp/${provider}/failure?` +
+            new URLSearchParams(params),
         },
       });
 

--- a/apps/login/src/lib/server/loginname.ts
+++ b/apps/login/src/lib/server/loginname.ts
@@ -53,10 +53,10 @@ export async function sendLoginname(command: SendLoginnameCommand) {
     });
 
     if (identityProviders.length === 1) {
-      const origin = (await headers()).get("origin");
+      const host = (await headers()).get("host");
 
-      if (!origin) {
-        return { error: "Could not get origin" };
+      if (!host) {
+        return { error: "Could not get host" };
       }
 
       const identityProviderType = identityProviders[0].type;
@@ -77,9 +77,11 @@ export async function sendLoginname(command: SendLoginnameCommand) {
         idpId: identityProviders[0].id,
         urls: {
           successUrl:
-            `${origin}/idp/${provider}/success?` + new URLSearchParams(params),
+            `${host.includes("localhost") ? "http://" : "https://"}${host}/idp/${provider}/success?` +
+            new URLSearchParams(params),
           failureUrl:
-            `${origin}/idp/${provider}/failure?` + new URLSearchParams(params),
+            `${host.includes("localhost") ? "http://" : "https://"}${host}/idp/${provider}/failure?` +
+            new URLSearchParams(params),
         },
       });
 
@@ -95,10 +97,10 @@ export async function sendLoginname(command: SendLoginnameCommand) {
     });
 
     if (identityProviders.length === 1) {
-      const origin = (await headers()).get("origin");
+      const host = (await headers()).get("host");
 
-      if (!origin) {
-        return { error: "Could not get origin" };
+      if (!host) {
+        return { error: "Could not get host" };
       }
 
       const identityProviderId = identityProviders[0].idpId;
@@ -128,9 +130,11 @@ export async function sendLoginname(command: SendLoginnameCommand) {
         idpId: idp.id,
         urls: {
           successUrl:
-            `${origin}/idp/${provider}/success?` + new URLSearchParams(params),
+            `${host.includes("localhost") ? "http://" : "https://"}${host}/idp/${provider}/success?` +
+            new URLSearchParams(params),
           failureUrl:
-            `${origin}/idp/${provider}/failure?` + new URLSearchParams(params),
+            `${host.includes("localhost") ? "http://" : "https://"}${host}/idp/${provider}/failure?` +
+            new URLSearchParams(params),
         },
       });
 

--- a/apps/login/src/lib/server/loginname.ts
+++ b/apps/login/src/lib/server/loginname.ts
@@ -53,10 +53,10 @@ export async function sendLoginname(command: SendLoginnameCommand) {
     });
 
     if (identityProviders.length === 1) {
-      const host = (await headers()).get("host");
+      const origin = (await headers()).get("origin");
 
-      if (!host) {
-        return { error: "Could not get host" };
+      if (!origin) {
+        return { error: "Could not get origin" };
       }
 
       const identityProviderType = identityProviders[0].type;
@@ -77,11 +77,9 @@ export async function sendLoginname(command: SendLoginnameCommand) {
         idpId: identityProviders[0].id,
         urls: {
           successUrl:
-            `${host.includes("localhost") ? "http://" : "https://"}${host}/idp/${provider}/success?` +
-            new URLSearchParams(params),
+            `${origin}/idp/${provider}/success?` + new URLSearchParams(params),
           failureUrl:
-            `${host.includes("localhost") ? "http://" : "https://"}${host}/idp/${provider}/failure?` +
-            new URLSearchParams(params),
+            `${origin}/idp/${provider}/failure?` + new URLSearchParams(params),
         },
       });
 
@@ -97,10 +95,10 @@ export async function sendLoginname(command: SendLoginnameCommand) {
     });
 
     if (identityProviders.length === 1) {
-      const host = (await headers()).get("host");
+      const origin = (await headers()).get("origin");
 
-      if (!host) {
-        return { error: "Could not get host" };
+      if (!origin) {
+        return { error: "Could not get origin" };
       }
 
       const identityProviderId = identityProviders[0].idpId;
@@ -130,11 +128,9 @@ export async function sendLoginname(command: SendLoginnameCommand) {
         idpId: idp.id,
         urls: {
           successUrl:
-            `${host.includes("localhost") ? "http://" : "https://"}${host}/idp/${provider}/success?` +
-            new URLSearchParams(params),
+            `${origin}/idp/${provider}/success?` + new URLSearchParams(params),
           failureUrl:
-            `${host.includes("localhost") ? "http://" : "https://"}${host}/idp/${provider}/failure?` +
-            new URLSearchParams(params),
+            `${origin}/idp/${provider}/failure?` + new URLSearchParams(params),
         },
       });
 

--- a/apps/login/src/lib/server/passkeys.ts
+++ b/apps/login/src/lib/server/passkeys.ts
@@ -40,7 +40,7 @@ export async function registerPasskeyLink(
   const host = (await headers()).get("host");
 
   if (!host) {
-    throw new Error("Could not get host");
+    throw new Error("Could not get domain");
   }
 
   const [hostname, port] = host.split(":");

--- a/apps/login/src/lib/server/passkeys.ts
+++ b/apps/login/src/lib/server/passkeys.ts
@@ -40,7 +40,7 @@ export async function registerPasskeyLink(
   const host = (await headers()).get("host");
 
   if (!host) {
-    throw new Error("Could not get domain");
+    throw new Error("Could not get host");
   }
 
   const [hostname, port] = host.split(":");

--- a/apps/login/src/lib/server/password.ts
+++ b/apps/login/src/lib/server/password.ts
@@ -31,7 +31,7 @@ type ResetPasswordCommand = {
 };
 
 export async function resetPassword(command: ResetPasswordCommand) {
-  const host = (await headers()).get("host");
+  const origin = (await headers()).get("origin");
 
   const users = await listUsers({
     loginName: command.loginName,
@@ -47,7 +47,7 @@ export async function resetPassword(command: ResetPasswordCommand) {
   }
   const userId = users.result[0].userId;
 
-  return passwordReset(userId, host, command.authRequestId);
+  return passwordReset(userId, origin, command.authRequestId);
 }
 
 export type UpdateSessionCommand = {

--- a/apps/login/src/lib/server/password.ts
+++ b/apps/login/src/lib/server/password.ts
@@ -31,7 +31,7 @@ type ResetPasswordCommand = {
 };
 
 export async function resetPassword(command: ResetPasswordCommand) {
-  const origin = (await headers()).get("origin");
+  const host = (await headers()).get("host");
 
   const users = await listUsers({
     loginName: command.loginName,
@@ -47,7 +47,7 @@ export async function resetPassword(command: ResetPasswordCommand) {
   }
   const userId = users.result[0].userId;
 
-  return passwordReset(userId, origin, command.authRequestId);
+  return passwordReset(userId, host, command.authRequestId);
 }
 
 export type UpdateSessionCommand = {

--- a/apps/login/src/lib/server/password.ts
+++ b/apps/login/src/lib/server/password.ts
@@ -149,7 +149,7 @@ export async function sendPassword(command: UpdateSessionCommand) {
   );
 
   const humanUser = user.type.case === "human" ? user.type.value : undefined;
-  console.log("humanUser", humanUser);
+
   if (
     availableSecondFactors?.length == 0 &&
     humanUser?.passwordChangeRequired

--- a/apps/login/src/lib/zitadel.ts
+++ b/apps/login/src/lib/zitadel.ts
@@ -267,15 +267,15 @@ export async function resendInviteCode(userId: string) {
   return userService.resendInviteCode({ userId }, {});
 }
 
-export async function createInviteCode(userId: string, origin: string | null) {
+export async function createInviteCode(userId: string, host: string | null) {
   let medium = create(SendInviteCodeSchema, {
     applicationName: "Typescript Login",
   });
 
-  if (origin) {
+  if (host) {
     medium = {
       ...medium,
-      urlTemplate: `${origin}/verify?code={{.Code}}&userId={{.UserID}}&organization={{.OrgID}}&invite=true`,
+      urlTemplate: `${host.includes("localhost") ? "http://" : "https://"}${host}/verify?code={{.Code}}&userId={{.UserID}}&organization={{.OrgID}}&invite=true`,
     };
   }
 
@@ -506,18 +506,18 @@ export function createUser(
  */
 export async function passwordReset(
   userId: string,
-  origin: string | null,
+  host: string | null,
   authRequestId?: string,
 ) {
   let medium = create(SendPasswordResetLinkSchema, {
     notificationType: NotificationType.Email,
   });
 
-  if (origin) {
+  if (host) {
     medium = {
       ...medium,
       urlTemplate:
-        `${origin}/password/set?code={{.Code}}&userId={{.UserID}}&organization={{.OrgID}}` +
+        `${host.includes("localhost") ? "http://" : "https://"}${host}/password/set?code={{.Code}}&userId={{.UserID}}&organization={{.OrgID}}` +
         (authRequestId ? `&authRequestId=${authRequestId}` : ""),
     };
   }

--- a/apps/login/src/lib/zitadel.ts
+++ b/apps/login/src/lib/zitadel.ts
@@ -267,15 +267,15 @@ export async function resendInviteCode(userId: string) {
   return userService.resendInviteCode({ userId }, {});
 }
 
-export async function createInviteCode(userId: string, host: string | null) {
+export async function createInviteCode(userId: string, origin: string | null) {
   let medium = create(SendInviteCodeSchema, {
     applicationName: "Typescript Login",
   });
 
-  if (host) {
+  if (origin) {
     medium = {
       ...medium,
-      urlTemplate: `${host.includes("localhost") ? "http://" : "https://"}${host}/verify?code={{.Code}}&userId={{.UserID}}&organization={{.OrgID}}&invite=true`,
+      urlTemplate: `${origin}/verify?code={{.Code}}&userId={{.UserID}}&organization={{.OrgID}}&invite=true`,
     };
   }
 
@@ -506,18 +506,18 @@ export function createUser(
  */
 export async function passwordReset(
   userId: string,
-  host: string | null,
+  origin: string | null,
   authRequestId?: string,
 ) {
   let medium = create(SendPasswordResetLinkSchema, {
     notificationType: NotificationType.Email,
   });
 
-  if (host) {
+  if (origin) {
     medium = {
       ...medium,
       urlTemplate:
-        `${host.includes("localhost") ? "http://" : "https://"}${host}/password/set?code={{.Code}}&userId={{.UserID}}&organization={{.OrgID}}` +
+        `${origin}/password/set?code={{.Code}}&userId={{.UserID}}&organization={{.OrgID}}` +
         (authRequestId ? `&authRequestId=${authRequestId}` : ""),
     };
   }


### PR DESCRIPTION
These features / fixes were implemented with this PR

- password change required is handled now. after a user password is checked, and if change is required, a user will be redirected to `/password/change`
- an additional check for force MFA is done, after checking a user password. If either forceMFA or forceLocalMFA is enforced, a user is prompted to setup MFA after password verification
- a password reset link now includes the authRequest if the flow was initiated with it 
- OTP links redirect to the same host where the flow was initiated and include the authRequest
- if phone / email login is disabled, user results are removed where the input equals the disabled method
- If passkeys / password is disabled, throw an error.


