### PR TITLE
chore(acceptance): use prod secret on command test:acceptance:prod

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,12 @@ jobs:
         if: ${{ matrix.command == 'test:acceptance' }}
 
       - name: Create Cloud Env File
-        run: echo "${{ matrix.command == 'test:acceptance:prod' && secrets.ENV_FILE_CONTENT_ACCEPTANCE_PROD || secrets.ENV_FILE_CONTENT_ACCEPTANCE_QA }}" | tee apps/login/.env.local acceptance/tests/.env.local > /dev/null
+        run: |
+          if [ "${{ matrix.command }}" == "test:acceptance:prod" ]; then
+            echo "${{ secrets.ENV_FILE_CONTENT_ACCEPTANCE_PROD }}" | tee apps/login/.env.local acceptance/tests/.env.local > /dev/null
+          else
+            echo "${{ secrets.ENV_FILE_CONTENT_ACCEPTANCE_QA }}" | tee apps/login/.env.local acceptance/tests/.env.local > /dev/null
+          fi
         if: ${{ matrix.command == 'test:acceptance:qa' || matrix.command == 'test:acceptance:prod' }}
 
       - name: Create Production Build


### PR DESCRIPTION
Acceptance tests with "test:acceptance:prod" run against QA. The reason is that the bash logical operators aren't evaluated as expected.

To fix this, we explicitly test the command in an if condition.

Completes #303 
Contributes to #51 

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [x] Cypress integration tests ensure that login app pages work as expected. The ZITADEL API is mocked.
- [x] No debug or dead code
- [x] My code has no repetitions
