### PR TITLE
fix: Finish IDP Signup for OIDC flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ You can already use the current state, and extend it with your needs.
   - [x] GitLab
   - [x] GitLab Enterprise
   - [x] Azure
-  - [ ] Apple
+  - [x] Apple
   - [x] Generic OIDC
-  - [ ] Generic OAuth
+  - [x] Generic OAuth
   - [ ] Generic JWT
   - [ ] LDAP
   - [ ] SAML SP

--- a/apps/login/readme.md
+++ b/apps/login/readme.md
@@ -396,3 +396,5 @@ Timebased features like the multifactor init prompt or password expiry, are not 
 - Login Settings: multifactor init prompt
 - forceMFA on login settings is not checked for IDPs
 - disablePhone / disableEmail from loginSettings will be implemented right after https://github.com/zitadel/zitadel/issues/9016 is merged
+
+Also note that IDP logins are considered as valid MFA. An additional MFA check will be implemented in future if enforced.

--- a/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
+++ b/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
@@ -204,5 +204,5 @@ export default async function Page(props: {
   }
 
   // return login failed if no linking or creation is allowed and no user was found
-  return loginFailed;
+  return loginFailed(branding);
 }

--- a/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
+++ b/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
@@ -179,12 +179,14 @@ export default async function Page(props: {
         );
       });
 
-      return linkingSuccess(
-        userId,
-        { idpIntentId: id, idpIntentToken: token },
-        authRequestId,
-        branding,
-      );
+      if (idpLink) {
+        return linkingSuccess(
+          idpInformation.userId,
+          { idpIntentId: id, idpIntentToken: token },
+          authRequestId,
+          branding,
+        );
+      }
     }
   }
 

--- a/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
+++ b/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
@@ -181,7 +181,7 @@ export default async function Page(props: {
 
       if (idpLink) {
         return linkingSuccess(
-          idpInformation.userId,
+          foundUser.userId,
           { idpIntentId: id, idpIntentToken: token },
           authRequestId,
           branding,

--- a/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
+++ b/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
@@ -14,7 +14,7 @@ import { AutoLinkingOption } from "@zitadel/proto/zitadel/idp/v2/idp_pb";
 import { BrandingSettings } from "@zitadel/proto/zitadel/settings/v2/branding_settings_pb";
 import { getLocale, getTranslations } from "next-intl/server";
 
-async function loginFailed(branding?: BrandingSettings) {
+async function loginFailed(branding?: BrandingSettings, error: string = "") {
   const locale = getLocale();
   const t = await getTranslations({ locale, namespace: "idp" });
 
@@ -22,9 +22,12 @@ async function loginFailed(branding?: BrandingSettings) {
     <DynamicTheme branding={branding}>
       <div className="flex flex-col items-center space-y-4">
         <h1>{t("loginError.title")}</h1>
-        <div className="w-full">
-          {<Alert type={AlertType.ALERT}>{t("loginError.title")}</Alert>}
-        </div>
+        <p className="ztdl-p">{t("loginError.title")}</p>
+        {error && (
+          <div className="w-full">
+            {<Alert type={AlertType.ALERT}>{error}</Alert>}
+          </div>
+        )}
       </div>
     </DynamicTheme>
   );
@@ -94,7 +97,7 @@ export default async function Page(props: {
   const branding = await getBrandingSettings(organization);
 
   if (!provider || !id || !token) {
-    return loginFailed(branding);
+    return loginFailed(branding, "IDP context missing");
   }
 
   const intent = await retrieveIDPIntent(id, token);
@@ -114,7 +117,7 @@ export default async function Page(props: {
   }
 
   if (!idpInformation) {
-    return loginFailed(branding);
+    return loginFailed(branding, "IDP information missing");
   }
 
   const idp = await getIDPByID(idpInformation.idpId);
@@ -204,5 +207,5 @@ export default async function Page(props: {
   }
 
   // return login failed if no linking or creation is allowed and no user was found
-  return loginFailed(branding);
+  return loginFailed(branding, "No user found");
 }

--- a/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
+++ b/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
@@ -22,7 +22,7 @@ async function loginFailed(branding?: BrandingSettings, error: string = "") {
     <DynamicTheme branding={branding}>
       <div className="flex flex-col items-center space-y-4">
         <h1>{t("loginError.title")}</h1>
-        <p className="ztdl-p">{t("loginError.title")}</p>
+        <p className="ztdl-p">{t("loginError.description")}</p>
         {error && (
           <div className="w-full">
             {<Alert type={AlertType.ALERT}>{error}</Alert>}
@@ -199,7 +199,12 @@ export default async function Page(props: {
         <DynamicTheme branding={branding}>
           <div className="flex flex-col items-center space-y-4">
             <h1>{t("registerSuccess.title")}</h1>
-            <div>{t("registerSuccess.description")}</div>
+            <p className="ztdl-p">{t("registerSuccess.description")}</p>
+            <IdpSignin
+              userId={newUser.userId}
+              idpIntent={{ idpIntentId: id, idpIntentToken: token }}
+              authRequestId={authRequestId}
+            />
           </div>
         </DynamicTheme>
       );

--- a/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
+++ b/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
@@ -84,6 +84,7 @@ export default async function Page(props: {
     return loginSuccess(
       userId,
       { idpIntentId: id, idpIntentToken: token },
+      authRequestId,
       branding,
     );
   }
@@ -155,6 +156,7 @@ export default async function Page(props: {
       return loginSuccess(
         userId,
         { idpIntentId: id, idpIntentToken: token },
+        authRequestId,
         branding,
       );
     }

--- a/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
+++ b/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
@@ -43,14 +43,13 @@ async function loginSuccess(
     <DynamicTheme branding={branding}>
       <div className="flex flex-col items-center space-y-4">
         <h1>{t("loginSuccess.title")}</h1>
-        <div>
-          {t("loginSuccess.description")}
-          <IdpSignin
-            userId={userId}
-            idpIntent={idpIntent}
-            authRequestId={authRequestId}
-          />
-        </div>
+        <p className="ztdl-p">{t("loginSuccess.description")}</p>
+
+        <IdpSignin
+          userId={userId}
+          idpIntent={idpIntent}
+          authRequestId={authRequestId}
+        />
       </div>
     </DynamicTheme>
   );
@@ -69,14 +68,13 @@ async function linkingSuccess(
     <DynamicTheme branding={branding}>
       <div className="flex flex-col items-center space-y-4">
         <h1>{t("linkingSuccess.title")}</h1>
-        <div>
-          {t("linkingSuccess.description")}
-          <IdpSignin
-            userId={userId}
-            idpIntent={idpIntent}
-            authRequestId={authRequestId}
-          />
-        </div>
+        <p className="ztdl-p">{t("linkingSuccess.description")}</p>
+
+        <IdpSignin
+          userId={userId}
+          idpIntent={idpIntent}
+          authRequestId={authRequestId}
+        />
       </div>
     </DynamicTheme>
   );

--- a/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
+++ b/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
@@ -56,6 +56,32 @@ async function loginSuccess(
   );
 }
 
+async function linkingSuccess(
+  userId: string,
+  idpIntent: { idpIntentId: string; idpIntentToken: string },
+  authRequestId?: string,
+  branding?: BrandingSettings,
+) {
+  const locale = getLocale();
+  const t = await getTranslations({ locale, namespace: "idp" });
+
+  return (
+    <DynamicTheme branding={branding}>
+      <div className="flex flex-col items-center space-y-4">
+        <h1>{t("linkingSuccess.title")}</h1>
+        <div>
+          {t("linkingSuccess.description")}
+          <IdpSignin
+            userId={userId}
+            idpIntent={idpIntent}
+            authRequestId={authRequestId}
+          />
+        </div>
+      </div>
+    </DynamicTheme>
+  );
+}
+
 export default async function Page(props: {
   searchParams: Promise<Record<string | number | symbol, string | undefined>>;
   params: Promise<{ provider: string }>;
@@ -153,7 +179,7 @@ export default async function Page(props: {
         );
       });
 
-      return loginSuccess(
+      return linkingSuccess(
         userId,
         { idpIntentId: id, idpIntentToken: token },
         authRequestId,

--- a/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
+++ b/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
@@ -29,6 +29,28 @@ async function loginFailed(branding?: BrandingSettings) {
     </DynamicTheme>
   );
 }
+
+async function loginSuccess(
+  userId: string,
+  idpIntent: { idpIntentId: string; idpIntentToken: string },
+  branding?: BrandingSettings,
+) {
+  const locale = getLocale();
+  const t = await getTranslations({ locale, namespace: "idp" });
+
+  return (
+    <DynamicTheme branding={branding}>
+      <div className="flex flex-col items-center space-y-4">
+        <h1>{t("loginSuccess.title")}</h1>
+        <div>
+          {t("loginSuccess.description")}
+          <IdpSignin userId={userId} idpIntent={idpIntent} />
+        </div>
+      </div>
+    </DynamicTheme>
+  );
+}
+
 export default async function Page(props: {
   searchParams: Promise<Record<string | number | symbol, string | undefined>>;
   params: Promise<{ provider: string }>;
@@ -54,11 +76,10 @@ export default async function Page(props: {
   if (userId && !link) {
     // TODO: update user if idp.options.isAutoUpdate is true
 
-    return (
-      <IdpSignin
-        userId={userId}
-        idpIntent={{ idpIntentId: id, idpIntentToken: token }}
-      />
+    return loginSuccess(
+      userId,
+      { idpIntentId: id, idpIntentToken: token },
+      branding,
     );
   }
 
@@ -126,11 +147,10 @@ export default async function Page(props: {
         );
       });
 
-      return (
-        <IdpSignin
-          userId={userId}
-          idpIntent={{ idpIntentId: id, idpIntentToken: token }}
-        />
+      return loginSuccess(
+        userId,
+        { idpIntentId: id, idpIntentToken: token },
+        branding,
       );
     }
   }

--- a/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
+++ b/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
@@ -33,6 +33,7 @@ async function loginFailed(branding?: BrandingSettings) {
 async function loginSuccess(
   userId: string,
   idpIntent: { idpIntentId: string; idpIntentToken: string },
+  authRequestId?: string,
   branding?: BrandingSettings,
 ) {
   const locale = getLocale();
@@ -44,7 +45,11 @@ async function loginSuccess(
         <h1>{t("loginSuccess.title")}</h1>
         <div>
           {t("loginSuccess.description")}
-          <IdpSignin userId={userId} idpIntent={idpIntent} />
+          <IdpSignin
+            userId={userId}
+            idpIntent={idpIntent}
+            authRequestId={authRequestId}
+          />
         </div>
       </div>
     </DynamicTheme>

--- a/apps/login/src/app/(login)/loginname/page.tsx
+++ b/apps/login/src/app/(login)/loginname/page.tsx
@@ -61,7 +61,7 @@ export default async function Page(props: {
             <SignInWithIdp
               identityProviders={identityProviders}
               authRequestId={authRequestId}
-              organization={organization ?? defaultOrganization} // use the organization from the searchParams here otherwise fallback to the default organization
+              organization={organization}
             ></SignInWithIdp>
           )}
         </UsernameForm>

--- a/apps/login/src/app/login/route.ts
+++ b/apps/login/src/app/login/route.ts
@@ -109,9 +109,10 @@ async function isSessionValid(session: Session): Promise<boolean> {
       const otpSms = session.factors.otpSms?.verifiedAt;
       const totp = session.factors.totp?.verifiedAt;
       const webAuthN = session.factors.webAuthN?.verifiedAt;
+      const idp = session.factors.intent?.verifiedAt; // TODO: forceMFA should not consider this as valid factor
 
       // must have one single check
-      mfaValid = !!(otpEmail || otpSms || totp || webAuthN);
+      mfaValid = !!(otpEmail || otpSms || totp || webAuthN || idp);
       if (!mfaValid) {
         console.warn("Session has no valid multifactor", session.factors);
       }
@@ -206,6 +207,8 @@ export async function GET(request: NextRequest) {
       console.log(`Found session ${selectedSession.id}`);
 
       const isValid = await isSessionValid(selectedSession);
+
+      console.log("Session is valid:", isValid);
 
       if (!isValid && selectedSession.factors?.user) {
         // if the session is not valid anymore, we need to redirect the user to re-authenticate

--- a/apps/login/src/app/login/route.ts
+++ b/apps/login/src/app/login/route.ts
@@ -211,7 +211,8 @@ export async function GET(request: NextRequest) {
       console.log("Session is valid:", isValid);
 
       if (!isValid && selectedSession.factors?.user) {
-        // if the session is not valid anymore, we need to redirect the user to re-authenticate
+        // if the session is not valid anymore, we need to redirect the user to re-authenticate /
+        // TODO: handle IDP intent direcly if available
         const command: SendLoginnameCommand = {
           loginName: selectedSession.factors.user?.loginName,
           organization: selectedSession.factors?.user?.organizationId,

--- a/apps/login/src/components/idp-signin.tsx
+++ b/apps/login/src/components/idp-signin.tsx
@@ -21,7 +21,7 @@ export function IdpSignin({
   idpIntent: { idpIntentId, idpIntentToken },
   authRequestId,
 }: Props) {
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const router = useRouter();
@@ -55,8 +55,8 @@ export function IdpSignin({
   }, []);
 
   return (
-    <div className="flex items-center justify-center">
-      {loading && <Spinner />}
+    <div className="flex items-center justify-center py-4">
+      {loading && <Spinner className="h-5 w-5" />}
       {error && (
         <div className="py-4">
           <Alert>{error}</Alert>

--- a/apps/login/src/lib/server/session.ts
+++ b/apps/login/src/lib/server/session.ts
@@ -60,8 +60,6 @@ export async function createNewSessionForIdp(options: CreateNewSessionCommand) {
     return { error: "Could not create session" };
   }
 
-  console.log("sessionForIdp", session, authRequestId, session.id);
-
   const url = await getNextUrl(
     authRequestId && session.id
       ? {

--- a/apps/login/src/lib/server/session.ts
+++ b/apps/login/src/lib/server/session.ts
@@ -60,6 +60,8 @@ export async function createNewSessionForIdp(options: CreateNewSessionCommand) {
     return { error: "Could not create session" };
   }
 
+  console.log("sessionForIdp", session, authRequestId, session.id);
+
   const url = await getNextUrl(
     authRequestId && session.id
       ? {

--- a/apps/login/src/lib/zitadel.ts
+++ b/apps/login/src/lib/zitadel.ts
@@ -10,8 +10,8 @@ import {
 import { createServerTransport } from "@zitadel/node";
 import { RequestChallenges } from "@zitadel/proto/zitadel/session/v2/challenge_pb";
 import { Checks } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
-import { IDPInformation } from "@zitadel/proto/zitadel/user/v2/idp_pb";
 import {
+  AddHumanUserRequest,
   RetrieveIdentityProviderIntentRequest,
   SetPasswordRequest,
   SetPasswordRequestSchema,
@@ -23,7 +23,6 @@ import { create, Duration } from "@zitadel/client";
 import { TextQueryMethod } from "@zitadel/proto/zitadel/object/v2/object_pb";
 import { CreateCallbackRequest } from "@zitadel/proto/zitadel/oidc/v2/oidc_service_pb";
 import { Organization } from "@zitadel/proto/zitadel/org/v2/org_pb";
-import { IdentityProviderType } from "@zitadel/proto/zitadel/settings/v2/login_settings_pb";
 import type { RedirectURLsJson } from "@zitadel/proto/zitadel/user/v2/idp_pb";
 import {
   NotificationType,
@@ -39,7 +38,6 @@ import {
   UserState,
 } from "@zitadel/proto/zitadel/user/v2/user_pb";
 import { unstable_cacheLife as cacheLife } from "next/cache";
-import { PROVIDER_MAPPING } from "./idp";
 
 const transport = createServerTransport(
   process.env.ZITADEL_SERVICE_USER_TOKEN!,
@@ -247,6 +245,10 @@ export async function addHumanUser({
       ? { case: "password", value: { password: password } }
       : undefined,
   });
+}
+
+export async function addHuman(request: AddHumanUserRequest) {
+  return userService.addHumanUser(request);
 }
 
 export async function verifyTOTPRegistration(code: string, userId: string) {
@@ -485,14 +487,6 @@ export function addIDPLink(
     },
     {},
   );
-}
-
-export function createUser(
-  provider: IdentityProviderType,
-  info: IDPInformation,
-) {
-  const userData = PROVIDER_MAPPING[provider](info);
-  return userService.addHumanUser(userData, {});
 }
 
 /**


### PR DESCRIPTION
This PR adds the OIDC authRequestId context to the IDP flow and fixes the callback after login, linking an register with IDP. It also implements domain discovery for the IDP flow.
 
### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [ ] Cypress integration tests ensure that login app pages work as expected on good and bad user inputs, ZITADEL responses or IDP redirects. The ZITADEL API is mocked, IDP redirects are simulated.
- [ ] Playwright acceptances tests ensure that the happy paths of common user journeys work as expected. The ZITADEL API is not mocked but IDP redirects are simulated.
- [x] No debug or dead code
- [x] My code has no repetitions
