### PR TITLE
fix: add grpc-web transport, fix release pnpm version

### DIFF
--- a/.changeset/fluffy-berries-thank.md
+++ b/.changeset/fluffy-berries-thank.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/client": patch
+---
+
+add missing client transport utility

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 10.0.0
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.0.0
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,9 +81,6 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Cypress
-        run: pnpm exec cypress install
-
         # We can cache the Playwright binary independently from the pnpm cache, because we install it separately.
         # After pnpm install --frozen-lockfile, we can get the version so we only have to download the binary once per version.
       - run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d ' ' -f 2)" >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,8 +68,8 @@ jobs:
           node-version: 20.x
           cache: 'pnpm'
 
-      - uses: actions/cache@v4.0.2
-        name: Setup Cypress binary cache
+      - name: Setup Cypress binary cache
+        uses: actions/cache@v4
         with:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-binary-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -81,13 +81,16 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Cypress
+        run: pnpm exec cypress install
+
         # We can cache the Playwright binary independently from the pnpm cache, because we install it separately.
         # After pnpm install --frozen-lockfile, we can get the version so we only have to download the binary once per version.
       - run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d ' ' -f 2)" >> $GITHUB_ENV
         if: ${{ startsWith(matrix.command, 'test:acceptance') }}
 
-      - uses: actions/cache@v4.0.2
-        name: Setup Playwright binary cache
+      - name: Setup Playwright binary cache
+        uses: actions/cache@v4
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "pnpm@9.1.2+sha256.19c17528f9ca20bd442e4ca42f00f1b9808a9cb419383cd04ba32ef19322aba7",
+  "packageManager": "pnpm@10.0.0",
   "private": true,
   "name": "typescript-monorepo",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "pnpm@10.0.0",
+  "packageManager": "pnpm@9.1.2+sha256.19c17528f9ca20bd442e4ca42f00f1b9808a9cb419383cd04ba32ef19322aba7",
   "private": true,
   "name": "typescript-monorepo",
   "scripts": {

--- a/packages/zitadel-client/src/node.ts
+++ b/packages/zitadel-client/src/node.ts
@@ -1,14 +1,27 @@
 import { createGrpcTransport, GrpcTransportOptions } from "@connectrpc/connect-node";
+import { createGrpcWebTransport } from "@connectrpc/connect-web";
 import { importPKCS8, SignJWT } from "jose";
 import { NewAuthorizationBearerInterceptor } from "./interceptors";
 
 /**
- * Create a server transport with the given token and configuration options.
+ * Create a server transport using grpc with the given token and configuration options.
  * @param token
  * @param opts
  */
 export function createServerTransport(token: string, opts: GrpcTransportOptions) {
   return createGrpcTransport({
+    ...opts,
+    interceptors: [...(opts.interceptors || []), NewAuthorizationBearerInterceptor(token)],
+  });
+}
+
+/**
+ * Create a client transport using grpc web with the given token and configuration options.
+ * @param token
+ * @param opts
+ */
+export function createClientTransport(token: string, opts: GrpcTransportOptions) {
+  return createGrpcWebTransport({
     ...opts,
     interceptors: [...(opts.interceptors || []), NewAuthorizationBearerInterceptor(token)],
   });


### PR DESCRIPTION
This PR adds an export utility to use grpc-web in browser environments
Fixes the version mismatch in `release.yml` and `package.json`
