### PR TITLE
fix(login): provide alternative auth methods when IDP failure page is shown

### DIFF
--- a/apps/login/src/components/choose-authenticator-to-login.tsx
+++ b/apps/login/src/components/choose-authenticator-to-login.tsx
@@ -1,0 +1,44 @@
+import {
+  LoginSettings,
+  PasskeysType,
+} from "@zitadel/proto/zitadel/settings/v2/login_settings_pb";
+import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
+import { useTranslations } from "next-intl";
+import { Alert, AlertType } from "./alert";
+import { PASSKEYS, PASSWORD } from "./auth-methods";
+
+type Props = {
+  authMethods: AuthenticationMethodType[];
+  params: URLSearchParams;
+  loginSettings: LoginSettings | undefined;
+};
+
+export function ChooseAuthenticatorToLogin({
+  authMethods,
+  params,
+  loginSettings,
+}: Props) {
+  const t = useTranslations("authenticator");
+
+  if (authMethods.length !== 0) {
+    return <Alert type={AlertType.ALERT}>{t("allSetup")}</Alert>;
+  } else {
+    return (
+      <>
+        {loginSettings?.passkeysType == PasskeysType.NOT_ALLOWED &&
+          !loginSettings.allowUsernamePassword && (
+            <Alert type={AlertType.ALERT}>{t("noMethodsAvailable")}</Alert>
+          )}
+
+        <div className="grid grid-cols-1 gap-5 w-full pt-4">
+          {!authMethods.includes(AuthenticationMethodType.PASSWORD) &&
+            loginSettings?.allowUsernamePassword &&
+            PASSWORD(false, "/password/set?" + params)}
+          {!authMethods.includes(AuthenticationMethodType.PASSKEY) &&
+            loginSettings?.passkeysType == PasskeysType.ALLOWED &&
+            PASSKEYS(false, "/passkey/set?" + params)}
+        </div>
+      </>
+    );
+  }
+}

--- a/apps/login/src/components/choose-authenticator-to-login.tsx
+++ b/apps/login/src/components/choose-authenticator-to-login.tsx
@@ -4,7 +4,6 @@ import {
 } from "@zitadel/proto/zitadel/settings/v2/login_settings_pb";
 import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 import { useTranslations } from "next-intl";
-import { Alert, AlertType } from "./alert";
 import { PASSKEYS, PASSWORD } from "./auth-methods";
 
 type Props = {
@@ -18,27 +17,22 @@ export function ChooseAuthenticatorToLogin({
   params,
   loginSettings,
 }: Props) {
-  const t = useTranslations("authenticator");
+  const t = useTranslations("idp");
 
-  if (authMethods.length !== 0) {
-    return <Alert type={AlertType.ALERT}>{t("allSetup")}</Alert>;
-  } else {
-    return (
-      <>
-        {loginSettings?.passkeysType == PasskeysType.NOT_ALLOWED &&
-          !loginSettings.allowUsernamePassword && (
-            <Alert type={AlertType.ALERT}>{t("noMethodsAvailable")}</Alert>
-          )}
-
-        <div className="grid grid-cols-1 gap-5 w-full pt-4">
-          {!authMethods.includes(AuthenticationMethodType.PASSWORD) &&
-            loginSettings?.allowUsernamePassword &&
-            PASSWORD(false, "/password/set?" + params)}
-          {!authMethods.includes(AuthenticationMethodType.PASSKEY) &&
-            loginSettings?.passkeysType == PasskeysType.ALLOWED &&
-            PASSKEYS(false, "/passkey/set?" + params)}
-        </div>
-      </>
-    );
-  }
+  return (
+    <>
+      {authMethods.includes(AuthenticationMethodType.PASSWORD) &&
+        loginSettings?.allowUsernamePassword && (
+          <div className="ztdl-p">Choose an alternative method to login </div>
+        )}
+      <div className="grid grid-cols-1 gap-5 w-full pt-4">
+        {authMethods.includes(AuthenticationMethodType.PASSWORD) &&
+          loginSettings?.allowUsernamePassword &&
+          PASSWORD(false, "/password?" + params)}
+        {authMethods.includes(AuthenticationMethodType.PASSKEY) &&
+          loginSettings?.passkeysType == PasskeysType.ALLOWED &&
+          PASSKEYS(false, "/passkey?" + params)}
+      </div>
+    </>
+  );
 }

--- a/apps/login/src/lib/server/loginname.ts
+++ b/apps/login/src/lib/server/loginname.ts
@@ -128,7 +128,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
       const identityProviderType = idpTypeToIdentityProviderType(idpType);
       const provider = idpTypeToSlug(identityProviderType);
 
-      const params = new URLSearchParams();
+      const params = new URLSearchParams({ userId });
 
       if (command.authRequestId) {
         params.set("authRequestId", command.authRequestId);


### PR DESCRIPTION

<img width="584" alt="Screenshot 2025-01-17 at 16 23 40" src="https://github.com/user-attachments/assets/ec8187a0-6f93-414a-84c7-69916323765e" />

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [ ] Cypress integration tests ensure that login app pages work as expected on good and bad user inputs, ZITADEL responses or IDP redirects. The ZITADEL API is mocked, IDP redirects are simulated.
- [ ] Playwright acceptances tests ensure that the happy paths of common user journeys work as expected. The ZITADEL API is not mocked but IDP redirects are simulated.
- [ ] No debug or dead code
- [ ] My code has no repetitions
