### PR TITLE
fix(@zitadel/client): grpc web transport export

### DIFF
--- a/.changeset/shiny-islands-sparkle.md
+++ b/.changeset/shiny-islands-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/client": patch
+---
+
+fix export for grpcweb transport

--- a/packages/zitadel-client/package.json
+++ b/packages/zitadel-client/package.json
@@ -31,6 +31,11 @@
       "types": "./dist/node.d.ts",
       "import": "./dist/node.js",
       "require": "./dist/node.cjs"
+    },
+    "./web": {
+      "types": "./dist/web.d.ts",
+      "import": "./dist/web.js",
+      "require": "./dist/web.cjs"
     }
   },
   "files": [

--- a/packages/zitadel-client/src/node.ts
+++ b/packages/zitadel-client/src/node.ts
@@ -1,5 +1,4 @@
 import { createGrpcTransport, GrpcTransportOptions } from "@connectrpc/connect-node";
-import { createGrpcWebTransport } from "@connectrpc/connect-web";
 import { importPKCS8, SignJWT } from "jose";
 import { NewAuthorizationBearerInterceptor } from "./interceptors";
 
@@ -10,18 +9,6 @@ import { NewAuthorizationBearerInterceptor } from "./interceptors";
  */
 export function createServerTransport(token: string, opts: GrpcTransportOptions) {
   return createGrpcTransport({
-    ...opts,
-    interceptors: [...(opts.interceptors || []), NewAuthorizationBearerInterceptor(token)],
-  });
-}
-
-/**
- * Create a client transport using grpc web with the given token and configuration options.
- * @param token
- * @param opts
- */
-export function createClientTransport(token: string, opts: GrpcTransportOptions) {
-  return createGrpcWebTransport({
     ...opts,
     interceptors: [...(opts.interceptors || []), NewAuthorizationBearerInterceptor(token)],
   });

--- a/packages/zitadel-client/src/web.ts
+++ b/packages/zitadel-client/src/web.ts
@@ -1,0 +1,15 @@
+import { GrpcTransportOptions } from "@connectrpc/connect-node";
+import { createGrpcWebTransport } from "@connectrpc/connect-web";
+import { NewAuthorizationBearerInterceptor } from "./interceptors";
+
+/**
+ * Create a client transport using grpc web with the given token and configuration options.
+ * @param token
+ * @param opts
+ */
+export function createClientTransport(token: string, opts: GrpcTransportOptions) {
+  return createGrpcWebTransport({
+    ...opts,
+    interceptors: [...(opts.interceptors || []), NewAuthorizationBearerInterceptor(token)],
+  });
+}

--- a/packages/zitadel-client/tsup.config.ts
+++ b/packages/zitadel-client/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, Options } from "tsup";
 
 export default defineConfig((options: Options) => ({
-  entry: ["src/index.ts", "src/v1.ts", "src/v2.ts", "src/v3alpha.ts", "src/node.ts"],
+  entry: ["src/index.ts", "src/v1.ts", "src/v2.ts", "src/v3alpha.ts", "src/node.ts", "src/web.ts"],
   format: ["esm", "cjs"],
   treeshake: false,
   splitting: true,


### PR DESCRIPTION
this moves grpc web transport to the import path /web to avoid issues on browser runtimes.