### PR TITLE
fix(@zitadel/client): broken imports in projects using node16/nodenext module resolution

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/iron

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ export ZITADEL_SERVICE_USER_TOKEN=<your service account personal access token he
 ### Setting up local environment
 
 ```sh
-# Install dependencies. Developing requires Node.js v16
+# Install dependencies. Developing requires Node.js v20
 pnpm install
 
 # Generate gRPC stubs

--- a/apps/login/package.json
+++ b/apps/login/package.json
@@ -62,7 +62,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
     "@types/ms": "0.7.34",
-    "@types/node": "22.9.0",
+    "@types/node": "^20.17.17",
     "@types/react": "19.0.2",
     "@types/react-dom": "19.0.2",
     "@types/tinycolor2": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@faker-js/faker": "^9.2.0",
     "@changesets/cli": "^2.27.9",
     "@playwright/test": "^1.48.2",
-    "@types/node": "^22.9.0",
+    "@types/node": "^20.17.17",
     "@vitejs/plugin-react": "^4.3.3",
     "@zitadel/prettier-config": "workspace:*",
     "axios": "^1.7.7",

--- a/packages/zitadel-client/src/index.ts
+++ b/packages/zitadel-client/src/index.ts
@@ -1,5 +1,5 @@
-export { createClientFor, toDate } from "./helpers";
-export { NewAuthorizationBearerInterceptor } from "./interceptors";
+export { createClientFor, toDate } from "./helpers.js";
+export { NewAuthorizationBearerInterceptor } from "./interceptors.js";
 
 // TODO: Move this to `./protobuf.ts` and export it from there
 export { create, fromJson, toJson } from "@bufbuild/protobuf";

--- a/packages/zitadel-client/src/interceptors.test.ts
+++ b/packages/zitadel-client/src/interceptors.test.ts
@@ -2,7 +2,7 @@ import { Int32Value } from "@bufbuild/protobuf/wkt";
 import { compileService } from "@bufbuild/protocompile";
 import { createRouterTransport, HandlerContext } from "@connectrpc/connect";
 import { describe, expect, test, vitest } from "vitest";
-import { NewAuthorizationBearerInterceptor } from "./interceptors";
+import { NewAuthorizationBearerInterceptor } from "./interceptors.js";
 
 const TestService = compileService(`
   syntax = "proto3";

--- a/packages/zitadel-client/src/node.ts
+++ b/packages/zitadel-client/src/node.ts
@@ -1,7 +1,7 @@
 import { createGrpcTransport, GrpcTransportOptions } from "@connectrpc/connect-node";
 import { createGrpcWebTransport } from "@connectrpc/connect-web";
 import { importPKCS8, SignJWT } from "jose";
-import { NewAuthorizationBearerInterceptor } from "./interceptors";
+import { NewAuthorizationBearerInterceptor } from "./interceptors.js";
 
 /**
  * Create a server transport using grpc with the given token and configuration options.

--- a/packages/zitadel-client/src/v1.ts
+++ b/packages/zitadel-client/src/v1.ts
@@ -1,9 +1,9 @@
-import { createClientFor } from "./helpers";
+import { createClientFor } from "./helpers.js";
 
-import { AdminService } from "@zitadel/proto/zitadel/admin_pb";
-import { AuthService } from "@zitadel/proto/zitadel/auth_pb";
-import { ManagementService } from "@zitadel/proto/zitadel/management_pb";
-import { SystemService } from "@zitadel/proto/zitadel/system_pb";
+import { AdminService } from "@zitadel/proto/zitadel/admin_pb.js";
+import { AuthService } from "@zitadel/proto/zitadel/auth_pb.js";
+import { ManagementService } from "@zitadel/proto/zitadel/management_pb.js";
+import { SystemService } from "@zitadel/proto/zitadel/system_pb.js";
 
 export const createAdminServiceClient = createClientFor(AdminService);
 export const createAuthServiceClient = createClientFor(AuthService);

--- a/packages/zitadel-client/src/v2.ts
+++ b/packages/zitadel-client/src/v2.ts
@@ -1,14 +1,14 @@
 import { create } from "@bufbuild/protobuf";
-import { FeatureService } from "@zitadel/proto/zitadel/feature/v2/feature_service_pb";
-import { IdentityProviderService } from "@zitadel/proto/zitadel/idp/v2/idp_service_pb";
-import { RequestContextSchema } from "@zitadel/proto/zitadel/object/v2/object_pb";
-import { OIDCService } from "@zitadel/proto/zitadel/oidc/v2/oidc_service_pb";
-import { OrganizationService } from "@zitadel/proto/zitadel/org/v2/org_service_pb";
-import { SessionService } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
-import { SettingsService } from "@zitadel/proto/zitadel/settings/v2/settings_service_pb";
-import { UserService } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
+import { FeatureService } from "@zitadel/proto/zitadel/feature/v2/feature_service_pb.js";
+import { IdentityProviderService } from "@zitadel/proto/zitadel/idp/v2/idp_service_pb.js";
+import { RequestContextSchema } from "@zitadel/proto/zitadel/object/v2/object_pb.js";
+import { OIDCService } from "@zitadel/proto/zitadel/oidc/v2/oidc_service_pb.js";
+import { OrganizationService } from "@zitadel/proto/zitadel/org/v2/org_service_pb.js";
+import { SessionService } from "@zitadel/proto/zitadel/session/v2/session_service_pb.js";
+import { SettingsService } from "@zitadel/proto/zitadel/settings/v2/settings_service_pb.js";
+import { UserService } from "@zitadel/proto/zitadel/user/v2/user_service_pb.js";
 
-import { createClientFor } from "./helpers";
+import { createClientFor } from "./helpers.js";
 
 export const createUserServiceClient = createClientFor(UserService);
 export const createSettingsServiceClient = createClientFor(SettingsService);

--- a/packages/zitadel-client/src/v3alpha.ts
+++ b/packages/zitadel-client/src/v3alpha.ts
@@ -1,6 +1,6 @@
-import { ZITADELUsers } from "@zitadel/proto/zitadel/resources/user/v3alpha/user_service_pb";
-import { ZITADELUserSchemas } from "@zitadel/proto/zitadel/resources/userschema/v3alpha/user_schema_service_pb";
-import { createClientFor } from "./helpers";
+import { ZITADELUsers } from "@zitadel/proto/zitadel/resources/user/v3alpha/user_service_pb.js";
+import { ZITADELUserSchemas } from "@zitadel/proto/zitadel/resources/userschema/v3alpha/user_schema_service_pb.js";
+import { createClientFor } from "./helpers.js";
 
 export const createUserSchemaServiceClient = createClientFor(ZITADELUserSchemas);
 export const createUserServiceClient = createClientFor(ZITADELUsers);

--- a/packages/zitadel-client/src/web.ts
+++ b/packages/zitadel-client/src/web.ts
@@ -1,6 +1,6 @@
 import { GrpcTransportOptions } from "@connectrpc/connect-node";
 import { createGrpcWebTransport } from "@connectrpc/connect-web";
-import { NewAuthorizationBearerInterceptor } from "./interceptors";
+import { NewAuthorizationBearerInterceptor } from "./interceptors.js";
 
 /**
  * Create a client transport using grpc web with the given token and configuration options.

--- a/packages/zitadel-proto/buf.gen.yaml
+++ b/packages/zitadel-proto/buf.gen.yaml
@@ -7,3 +7,4 @@ plugins:
     include_imports: true
     opt:
       - json_types=true
+      - import_extension=js

--- a/packages/zitadel-tsconfig/tsup.json
+++ b/packages/zitadel-tsconfig/tsup.json
@@ -1,9 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "tsup",
-  "extends": "./node20.json",
-  "compilerOptions": {
-    "module": "preserve",
-    "moduleResolution": "Bundler"
-  }
+  "extends": "./node20.json"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,11 +30,11 @@ importers:
         specifier: ^1.48.2
         version: 1.48.2
       '@types/node':
-        specifier: ^22.9.0
-        version: 22.9.0
+        specifier: ^20.17.17
+        version: 20.17.17
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.11(@types/node@22.9.0)(sass@1.80.7))
+        version: 4.3.3(vite@5.4.11(@types/node@20.17.17)(sass@1.80.7))
       '@zitadel/eslint-config':
         specifier: workspace:*
         version: link:packages/zitadel-eslint-config
@@ -67,10 +67,10 @@ importers:
         version: 5.6.3
       vite-tsconfig-paths:
         specifier: ^5.1.2
-        version: 5.1.2(typescript@5.6.3)(vite@5.4.11(@types/node@22.9.0)(sass@1.80.7))
+        version: 5.1.2(typescript@5.6.3)(vite@5.4.11(@types/node@20.17.17)(sass@1.80.7))
       vitest:
         specifier: ^2.1.4
-        version: 2.1.4(@types/node@22.9.0)(jsdom@25.0.1)(sass@1.80.7)
+        version: 2.1.4(@types/node@20.17.17)(jsdom@25.0.1)(sass@1.80.7)
 
   apps/login:
     dependencies:
@@ -151,8 +151,8 @@ importers:
         specifier: 0.7.34
         version: 0.7.34
       '@types/node':
-        specifier: 22.9.0
-        version: 22.9.0
+        specifier: ^20.17.17
+        version: 20.17.17
       '@types/react':
         specifier: 19.0.2
         version: 19.0.2
@@ -1554,8 +1554,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@22.9.0':
-    resolution: {integrity: sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==}
+  '@types/node@20.17.17':
+    resolution: {integrity: sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==}
 
   '@types/react-dom@19.0.2':
     resolution: {integrity: sha512-c1s+7TKFaDRRxr1TxccIX2u7sfCnc3RxkVyBIUA2lCpyqCF+QoAwQ/CBg7bsMdVwP120HEH143VQezKtef5nCg==}
@@ -6011,7 +6011,7 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@22.9.0':
+  '@types/node@20.17.17':
     dependencies:
       undici-types: 6.19.8
 
@@ -6033,7 +6033,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.9.0
+      '@types/node': 20.17.17
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.15.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)':
@@ -6156,14 +6156,14 @@ snapshots:
 
   '@vercel/git-hooks@1.0.0': {}
 
-  '@vitejs/plugin-react@4.3.3(vite@5.4.11(@types/node@22.9.0)(sass@1.80.7))':
+  '@vitejs/plugin-react@4.3.3(vite@5.4.11(@types/node@20.17.17)(sass@1.80.7))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.11(@types/node@22.9.0)(sass@1.80.7)
+      vite: 5.4.11(@types/node@20.17.17)(sass@1.80.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -6174,13 +6174,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.4(vite@5.4.11(@types/node@22.9.0)(sass@1.80.7))':
+  '@vitest/mocker@2.1.4(vite@5.4.11(@types/node@20.17.17)(sass@1.80.7))':
     dependencies:
       '@vitest/spy': 2.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.12
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.9.0)(sass@1.80.7)
+      vite: 5.4.11(@types/node@20.17.17)(sass@1.80.7)
 
   '@vitest/pretty-format@2.1.4':
     dependencies:
@@ -7107,7 +7107,7 @@ snapshots:
       debug: 4.3.7(supports-color@5.5.0)
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.8.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-module-utils: 2.8.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.0
       is-bun-module: 1.1.0
@@ -7120,7 +7120,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
+  eslint-module-utils@2.8.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
@@ -7141,7 +7141,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-module-utils: 2.8.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -8586,7 +8586,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 22.9.0
+      '@types/node': 20.17.17
       long: 5.2.3
 
   proxy-from-env@1.0.0: {}
@@ -9391,12 +9391,12 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  vite-node@2.1.4(@types/node@22.9.0)(sass@1.80.7):
+  vite-node@2.1.4(@types/node@20.17.17)(sass@1.80.7):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7(supports-color@5.5.0)
       pathe: 1.1.2
-      vite: 5.4.11(@types/node@22.9.0)(sass@1.80.7)
+      vite: 5.4.11(@types/node@20.17.17)(sass@1.80.7)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -9408,31 +9408,31 @@ snapshots:
       - supports-color
       - terser
 
-  vite-tsconfig-paths@5.1.2(typescript@5.6.3)(vite@5.4.11(@types/node@22.9.0)(sass@1.80.7)):
+  vite-tsconfig-paths@5.1.2(typescript@5.6.3)(vite@5.4.11(@types/node@20.17.17)(sass@1.80.7)):
     dependencies:
       debug: 4.3.7(supports-color@5.5.0)
       globrex: 0.1.2
       tsconfck: 3.1.4(typescript@5.6.3)
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.9.0)(sass@1.80.7)
+      vite: 5.4.11(@types/node@20.17.17)(sass@1.80.7)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@5.4.11(@types/node@22.9.0)(sass@1.80.7):
+  vite@5.4.11(@types/node@20.17.17)(sass@1.80.7):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.49
       rollup: 4.25.0
     optionalDependencies:
-      '@types/node': 22.9.0
+      '@types/node': 20.17.17
       fsevents: 2.3.3
       sass: 1.80.7
 
-  vitest@2.1.4(@types/node@22.9.0)(jsdom@25.0.1)(sass@1.80.7):
+  vitest@2.1.4(@types/node@20.17.17)(jsdom@25.0.1)(sass@1.80.7):
     dependencies:
       '@vitest/expect': 2.1.4
-      '@vitest/mocker': 2.1.4(vite@5.4.11(@types/node@22.9.0)(sass@1.80.7))
+      '@vitest/mocker': 2.1.4(vite@5.4.11(@types/node@20.17.17)(sass@1.80.7))
       '@vitest/pretty-format': 2.1.4
       '@vitest/runner': 2.1.4
       '@vitest/snapshot': 2.1.4
@@ -9448,11 +9448,11 @@ snapshots:
       tinyexec: 0.3.1
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@22.9.0)(sass@1.80.7)
-      vite-node: 2.1.4(@types/node@22.9.0)(sass@1.80.7)
+      vite: 5.4.11(@types/node@20.17.17)(sass@1.80.7)
+      vite-node: 2.1.4(@types/node@20.17.17)(sass@1.80.7)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.9.0
+      '@types/node': 20.17.17
       jsdom: 25.0.1
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
While the `@zitadel/client` package might work perfectly in `moduleResolution: Bundler` based packages, that is not the case with `moduleResolution: nodenext`. The imports in declaration (`.d.ts`) files generated by tsup do not include the `.js` extension, which is required for successful resolution.

The solution was to add the extension to all files in the package. To make sure that the extension is required, I have removed `moduleResolution: Bundler` from the tsup tsconfig file (letting it fall back on the node20 tsconfig file). I have also removed `module: preserve`, as without `moduleResolution: Bundler`, type imports were failing (same as for me when I tried using `@zitadel/client` in my package). I noticed this in the `interceptors.ts` file, where the `Header` type resolved to `any`.

I have also set the `@types/node` import version to `20`, as that appears to be the version the repo is set up for. To make the desired version clear, I have also added an `.nvmrc` file.

Also, I suggest you guys use [tsconfig/bases](https://github.com/tsconfig/bases), we've been using them for a while, and not having to deal with the weirdness of tsconfig has been refreshing 😃

Edit: Looks like there were issues with imports inside of the `@zitadel/proto` package, I've added an option to generate the extensions there as well.
