### PR TITLE
feat: allow configuring custom request headers

### DIFF
--- a/apps/login/next-env-vars.d.ts
+++ b/apps/login/next-env-vars.d.ts
@@ -27,5 +27,11 @@ declare namespace NodeJS {
      * Optional: wheter a user must have verified email
      */
     EMAIL_VERIFICATION: string;
+
+    /**
+     * Optional: custom request headers to be added to every request
+     * Split by comma, key value pairs separated by colon
+     */
+    CUSTOM_REQUEST_HEADERS: string;
   }
 }

--- a/apps/login/src/lib/service.ts
+++ b/apps/login/src/lib/service.ts
@@ -44,18 +44,21 @@ export async function createServiceForHost<T extends ServiceClass>(
 
   const transport = createServerTransport(token, {
     baseUrl: serviceUrl,
-    interceptors: !process.env.CUSTOM_REQUEST_HEADERS ? undefined :[
-      (next) => {
-        return (req) => {
-          process.env.CUSTOM_REQUEST_HEADERS.split(",").forEach((header) => {
-            const kv = header.split(":")
-            req.header.set(kv[0], kv[1]);
-          })
-          return next(req);
-        };
-      },
-    ]
-    ,
+    interceptors: !process.env.CUSTOM_REQUEST_HEADERS
+      ? undefined
+      : [
+          (next) => {
+            return (req) => {
+              process.env.CUSTOM_REQUEST_HEADERS.split(",").forEach(
+                (header) => {
+                  const kv = header.split(":");
+                  req.header.set(kv[0], kv[1]);
+                },
+              );
+              return next(req);
+            };
+          },
+        ],
   });
 
   return createClientFor<T>(service)(transport);

--- a/apps/login/src/lib/service.ts
+++ b/apps/login/src/lib/service.ts
@@ -44,6 +44,18 @@ export async function createServiceForHost<T extends ServiceClass>(
 
   const transport = createServerTransport(token, {
     baseUrl: serviceUrl,
+    interceptors: !process.env.CUSTOM_REQUEST_HEADERS ? undefined :[
+      (next) => {
+        return (req) => {
+          process.env.CUSTOM_REQUEST_HEADERS.split(",").forEach((header) => {
+            const kv = header.split(":")
+            req.header.set(kv[0], kv[1]);
+          })
+          return next(req);
+        };
+      },
+    ]
+    ,
   });
 
   return createClientFor<T>(service)(transport);

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,8 @@
     "ZITADEL_API_URL",
     "ZITADEL_SERVICE_USER_ID",
     "ZITADEL_SERVICE_USER_TOKEN",
-    "NEXT_PUBLIC_BASE_PATH"
+    "NEXT_PUBLIC_BASE_PATH",
+    "CUSTOM_REQUEST_HEADERS"
   ],
   "tasks": {
     "generate": {


### PR DESCRIPTION
Allows configuring custom request headers for all outgoing gRPC connections.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [ ] Cypress integration tests ensure that login app pages work as expected on good and bad user inputs, ZITADEL responses or IDP redirects. The ZITADEL API is mocked, IDP redirects are simulated.
- [ ] Playwright acceptances tests ensure that the happy paths of common user journeys work as expected. The ZITADEL API is not mocked but IDP redirects are simulated.
- [ ] No debug or dead code
- [ ] My code has no repetitions
