### PR TITLE
chore(docker): use better base path

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,7 +58,7 @@ jobs:
         run: pnpm install
 
       - name: Build for Docker
-        run: NEXT_PUBLIC_BASE_PATH=/new-login pnpm build:docker
+        run: NEXT_PUBLIC_BASE_PATH=/ui/v2/login pnpm build:docker
 
       - name: Build and Push Image
         id: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,16 +68,6 @@ jobs:
           node-version: 20.x
           cache: 'pnpm'
 
-      - name: Setup Cypress binary cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/Cypress
-          key: ${{ runner.os }}-cypress-binary-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-cypress-binary-
-        # The Cypress binary cache needs to be updated together with the pnpm dependencies cache.
-        # That's why we don't conditionally cache it using if: ${{ matrix.command == 'test:integration' }}
-
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: 'pnpm'
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
We provide the login at /ui/v2/login

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [x] Cypress integration tests ensure that login app pages work as expected on good and bad user inputs, ZITADEL responses or IDP redirects. The ZITADEL API is mocked, IDP redirects are simulated.
- [x] Playwright acceptances tests ensure that the happy paths of common user journeys work as expected. The ZITADEL API is not mocked but IDP redirects are simulated.
- [x] No debug or dead code
- [x] My code has no repetitions
