### PR TITLE
fix: construct url using host

### DIFF
--- a/apps/login/src/app/login/route.ts
+++ b/apps/login/src/app/login/route.ts
@@ -66,19 +66,6 @@ async function loadSessions({
   return response?.sessions ?? [];
 }
 
-export function constructUrl(request: NextRequest, path: string) {
-  const forwardedHost =
-    request.headers.get("x-zitadel-forward-host") ??
-    request.headers.get("host");
-  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
-  return new URL(
-    `${basePath}${path}`,
-    forwardedHost?.startsWith("http")
-      ? forwardedHost
-      : `https://${forwardedHost}`,
-  );
-}
-
 const ORG_SCOPE_REGEX = /urn:zitadel:iam:org:id:([0-9]+)/;
 const ORG_DOMAIN_SCOPE_REGEX = /urn:zitadel:iam:org:domain:primary:(.+)/; // TODO: check regex for all domain character options
 const IDP_SCOPE_REGEX = /urn:zitadel:iam:org:idp:id:(.+)/;

--- a/apps/login/src/app/login/route.ts
+++ b/apps/login/src/app/login/route.ts
@@ -3,7 +3,7 @@ import { idpTypeToSlug } from "@/lib/idp";
 import { loginWithOIDCandSession } from "@/lib/oidc";
 import { loginWithSAMLandSession } from "@/lib/saml";
 import { sendLoginname, SendLoginnameCommand } from "@/lib/server/loginname";
-import { getServiceUrlFromHeaders } from "@/lib/service";
+import { constructUrl, getServiceUrlFromHeaders } from "@/lib/service";
 import { findValidSession } from "@/lib/session";
 import {
   createCallback,

--- a/apps/login/src/lib/oidc.ts
+++ b/apps/login/src/lib/oidc.ts
@@ -1,3 +1,4 @@
+import { constructUrl } from "@/app/login/route";
 import { Cookie } from "@/lib/cookies";
 import { sendLoginname, SendLoginnameCommand } from "@/lib/server/loginname";
 import { createCallback, getLoginSettings } from "@/lib/zitadel";
@@ -54,7 +55,7 @@ export async function loginWithOIDCandSession({
       const res = await sendLoginname(command);
 
       if (res && "redirect" in res && res?.redirect) {
-        const absoluteUrl = new URL(res.redirect, request.url);
+        const absoluteUrl = constructUrl(request, res.redirect);
         return NextResponse.redirect(absoluteUrl.toString());
       }
     }
@@ -107,7 +108,7 @@ export async function loginWithOIDCandSession({
             return NextResponse.redirect(loginSettings.defaultRedirectUri);
           }
 
-          const signedinUrl = new URL("/signedin", request.url);
+          const signedinUrl = constructUrl(request, "/signedin");
 
           if (selectedSession.factors?.user?.loginName) {
             signedinUrl.searchParams.set(

--- a/apps/login/src/lib/oidc.ts
+++ b/apps/login/src/lib/oidc.ts
@@ -1,4 +1,3 @@
-import { constructUrl } from "@/app/login/route";
 import { Cookie } from "@/lib/cookies";
 import { sendLoginname, SendLoginnameCommand } from "@/lib/server/loginname";
 import { createCallback, getLoginSettings } from "@/lib/zitadel";
@@ -9,6 +8,7 @@ import {
 } from "@zitadel/proto/zitadel/oidc/v2/oidc_service_pb";
 import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
 import { NextRequest, NextResponse } from "next/server";
+import { constructUrl } from "./service";
 import { isSessionValid } from "./session";
 
 type LoginWithOIDCandSession = {

--- a/apps/login/src/lib/saml.ts
+++ b/apps/login/src/lib/saml.ts
@@ -1,4 +1,3 @@
-import { constructUrl } from "@/app/login/route";
 import { Cookie } from "@/lib/cookies";
 import { sendLoginname, SendLoginnameCommand } from "@/lib/server/loginname";
 import { createResponse, getLoginSettings } from "@/lib/zitadel";
@@ -6,6 +5,7 @@ import { create } from "@zitadel/client";
 import { CreateResponseRequestSchema } from "@zitadel/proto/zitadel/saml/v2/saml_service_pb";
 import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
 import { NextRequest, NextResponse } from "next/server";
+import { constructUrl } from "./service";
 import { isSessionValid } from "./session";
 
 type LoginWithSAMLandSession = {

--- a/apps/login/src/lib/saml.ts
+++ b/apps/login/src/lib/saml.ts
@@ -1,3 +1,4 @@
+import { constructUrl } from "@/app/login/route";
 import { Cookie } from "@/lib/cookies";
 import { sendLoginname, SendLoginnameCommand } from "@/lib/server/loginname";
 import { createResponse, getLoginSettings } from "@/lib/zitadel";
@@ -52,7 +53,7 @@ export async function loginWithSAMLandSession({
       const res = await sendLoginname(command);
 
       if (res && "redirect" in res && res?.redirect) {
-        const absoluteUrl = new URL(res.redirect, request.url);
+        const absoluteUrl = constructUrl(request, res.redirect);
         return NextResponse.redirect(absoluteUrl.toString());
       }
     }
@@ -105,7 +106,7 @@ export async function loginWithSAMLandSession({
             return NextResponse.redirect(loginSettings.defaultRedirectUri);
           }
 
-          const signedinUrl = new URL("/signedin", request.url);
+          const signedinUrl = constructUrl(request, "/signedin");
 
           if (selectedSession.factors?.user?.loginName) {
             signedinUrl.searchParams.set(

--- a/apps/login/src/lib/service.ts
+++ b/apps/login/src/lib/service.ts
@@ -119,10 +119,6 @@ export function constructUrl(request: NextRequest, path: string) {
   const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
   return new URL(
     `${basePath}${path}`,
-
-    // keep this check to allow localhost for local development
-    forwardedHost?.startsWith("http")
-      ? forwardedHost
-      : `${forwardedProto}://${forwardedHost}`,
+    `${forwardedProto}//${forwardedHost}`,
   );
 }

--- a/apps/login/src/lib/service.ts
+++ b/apps/login/src/lib/service.ts
@@ -111,7 +111,7 @@ export function getServiceUrlFromHeaders(headers: ReadonlyHeaders): {
 }
 
 export function constructUrl(request: NextRequest, path: string) {
-  const forwardedProto = request.headers.get("x-forwarded-proto") ?? "https";
+  const forwardedProto = request.headers.get("x-forwarded-proto") ? `${request.headers.get("x-forwarded-proto")}:` : request.protocol;
 
   const forwardedHost =
     request.headers.get("x-zitadel-forward-host") ??

--- a/apps/login/src/lib/service.ts
+++ b/apps/login/src/lib/service.ts
@@ -111,15 +111,14 @@ export function getServiceUrlFromHeaders(headers: ReadonlyHeaders): {
 }
 
 export function constructUrl(request: NextRequest, path: string) {
-  const forwardedProto = request.headers.get("x-forwarded-proto") ? `${request.headers.get("x-forwarded-proto")}:` : request.protocol;
+  const forwardedProto = request.headers.get("x-forwarded-proto")
+    ? `${request.headers.get("x-forwarded-proto")}:`
+    : request.protocol;
 
   const forwardedHost =
     request.headers.get("x-zitadel-forward-host") ??
     request.headers.get("x-forwarded-host") ??
     request.headers.get("host");
   const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
-  return new URL(
-    `${basePath}${path}`,
-    `${forwardedProto}//${forwardedHost}`,
-  );
+  return new URL(`${basePath}${path}`, `${forwardedProto}//${forwardedHost}`);
 }

--- a/apps/login/src/lib/service.ts
+++ b/apps/login/src/lib/service.ts
@@ -8,6 +8,7 @@ import { SessionService } from "@zitadel/proto/zitadel/session/v2/session_servic
 import { SettingsService } from "@zitadel/proto/zitadel/settings/v2/settings_service_pb";
 import { UserService } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 import { ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
+import { NextRequest } from "next/server";
 import { systemAPIToken } from "./api";
 
 type ServiceClass =
@@ -107,4 +108,17 @@ export function getServiceUrlFromHeaders(headers: ReadonlyHeaders): {
   return {
     serviceUrl: instanceUrl,
   };
+}
+
+export function constructUrl(request: NextRequest, path: string) {
+  const forwardedHost =
+    request.headers.get("x-zitadel-forward-host") ??
+    request.headers.get("host");
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+  return new URL(
+    `${basePath}${path}`,
+    forwardedHost?.startsWith("http")
+      ? forwardedHost
+      : `https://${forwardedHost}`,
+  );
 }

--- a/apps/login/src/lib/service.ts
+++ b/apps/login/src/lib/service.ts
@@ -115,6 +115,7 @@ export function constructUrl(request: NextRequest, path: string) {
 
   const forwardedHost =
     request.headers.get("x-zitadel-forward-host") ??
+    request.headers.get("x-forwarded-host") ??
     request.headers.get("host");
   const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
   return new URL(

--- a/apps/login/src/lib/service.ts
+++ b/apps/login/src/lib/service.ts
@@ -111,14 +111,19 @@ export function getServiceUrlFromHeaders(headers: ReadonlyHeaders): {
 }
 
 export function constructUrl(request: NextRequest, path: string) {
+  const forwardedProto =
+    request.headers.get("x-forwarded-proto") ?? request.nextUrl.protocol;
+
   const forwardedHost =
     request.headers.get("x-zitadel-forward-host") ??
     request.headers.get("host");
   const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
   return new URL(
     `${basePath}${path}`,
+
+    // keep this check to allow localhost for local development
     forwardedHost?.startsWith("http")
       ? forwardedHost
-      : `https://${forwardedHost}`,
+      : `${forwardedProto}//${forwardedHost}`,
   );
 }

--- a/apps/login/src/lib/service.ts
+++ b/apps/login/src/lib/service.ts
@@ -111,8 +111,7 @@ export function getServiceUrlFromHeaders(headers: ReadonlyHeaders): {
 }
 
 export function constructUrl(request: NextRequest, path: string) {
-  const forwardedProto =
-    request.headers.get("x-forwarded-proto") ?? request.nextUrl.protocol;
+  const forwardedProto = request.headers.get("x-forwarded-proto") ?? "https";
 
   const forwardedHost =
     request.headers.get("x-zitadel-forward-host") ??
@@ -124,6 +123,6 @@ export function constructUrl(request: NextRequest, path: string) {
     // keep this check to allow localhost for local development
     forwardedHost?.startsWith("http")
       ? forwardedHost
-      : `${forwardedProto}//${forwardedHost}`,
+      : `${forwardedProto}://${forwardedHost}`,
   );
 }

--- a/apps/login/src/lib/service.ts
+++ b/apps/login/src/lib/service.ts
@@ -113,7 +113,7 @@ export function getServiceUrlFromHeaders(headers: ReadonlyHeaders): {
 export function constructUrl(request: NextRequest, path: string) {
   const forwardedProto = request.headers.get("x-forwarded-proto")
     ? `${request.headers.get("x-forwarded-proto")}:`
-    : request.protocol;
+    : request.nextUrl.protocol;
 
   const forwardedHost =
     request.headers.get("x-zitadel-forward-host") ??


### PR DESCRIPTION
This PR changes the behaviour of the login route (which is responsible to handle OIDC and SAML requests) to use the host header instead of the request.url to construct any further redirects. 

Note: This is essential in a docker environment behind a reverse proxy but not for vercel deployments

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [ ] Cypress integration tests ensure that login app pages work as expected on good and bad user inputs, ZITADEL responses or IDP redirects. The ZITADEL API is mocked, IDP redirects are simulated.
- [ ] Playwright acceptances tests ensure that the happy paths of common user journeys work as expected. The ZITADEL API is not mocked but IDP redirects are simulated.
- [ ] No debug or dead code
- [ ] My code has no repetitions
