### PR TITLE
fix(SAML): add saml paths to proxy

### DIFF
--- a/apps/login/src/middleware.ts
+++ b/apps/login/src/middleware.ts
@@ -8,6 +8,7 @@ export const config = {
     "/oauth/:path*",
     "/oidc/:path*",
     "/idps/callback/:path*",
+    "/saml/:path*",
   ],
 };
 


### PR DESCRIPTION
For self hosters, saml endpoints need to be proxied through the middleware. This PR adds the required domains to the middlware matcher function.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [ ] Cypress integration tests ensure that login app pages work as expected on good and bad user inputs, ZITADEL responses or IDP redirects. The ZITADEL API is mocked, IDP redirects are simulated.
- [ ] Playwright acceptances tests ensure that the happy paths of common user journeys work as expected. The ZITADEL API is not mocked but IDP redirects are simulated.
- [ ] No debug or dead code
- [ ] My code has no repetitions
