### PR TITLE
fix(saml): requestId serializing

### DIFF
--- a/apps/login/src/app/login/route.ts
+++ b/apps/login/src/app/login/route.ts
@@ -81,9 +81,12 @@ export async function GET(request: NextRequest) {
 
   // internal request id which combines authRequest and samlRequest with the prefix oidc_ or saml_
   let requestId =
-    searchParams.get("requestId") ||
-    `oidc_${oidcRequestId}` ||
-    `saml_${samlRequestId}`;
+    searchParams.get("requestId") ??
+    (oidcRequestId
+      ? `oidc_${oidcRequestId}`
+      : samlRequestId
+        ? `saml_${samlRequestId}`
+        : undefined);
 
   const sessionId = searchParams.get("sessionId");
 

--- a/apps/login/src/app/login/route.ts
+++ b/apps/login/src/app/login/route.ts
@@ -481,12 +481,10 @@ export async function GET(request: NextRequest) {
         };
 
         // Convert form data to URL-encoded string
-        const formBody = Object.entries(formData)
-          .map(
-            ([key, value]) =>
-              encodeURIComponent(key) + "=" + encodeURIComponent(value),
-          )
-          .join("&");
+        const formBody = new FormData();
+
+        formBody.append("relayState", formData.relayState);
+        formBody.append("samlResponse", formData.samlResponse);
 
         // Make a POST request to the external URL with the form data
         const response = await fetch(url, {

--- a/apps/login/src/app/login/route.ts
+++ b/apps/login/src/app/login/route.ts
@@ -476,8 +476,8 @@ export async function GET(request: NextRequest) {
         return NextResponse.redirect(url);
       } else if (url && binding.case === "post") {
         const formData = {
-          key1: "value1",
-          key2: "value2",
+          relayState: binding.value.relayState,
+          samlResponse: binding.value.samlResponse,
         };
 
         // Convert form data to URL-encoded string

--- a/apps/login/src/app/login/route.ts
+++ b/apps/login/src/app/login/route.ts
@@ -483,9 +483,10 @@ export async function GET(request: NextRequest) {
         // Convert form data to URL-encoded string
         const formBody = new FormData();
 
-        formBody.append("relayState", formData.relayState);
-        formBody.append("samlResponse", formData.samlResponse);
-
+        formBody.append("RelayState", formData.relayState);
+        formBody.append("SAMLResponse", formData.samlResponse);
+        console.log(url)
+        console.log(formBody)
         // Make a POST request to the external URL with the form data
         const response = await fetch(url, {
           method: "POST",
@@ -494,6 +495,7 @@ export async function GET(request: NextRequest) {
           },
           body: formBody,
         });
+        console.log(response)
 
         // Handle the response from the external URL
         if (response.ok) {

--- a/apps/login/src/app/login/route.ts
+++ b/apps/login/src/app/login/route.ts
@@ -477,17 +477,17 @@ export async function GET(request: NextRequest) {
       } else if (url && binding.case === "post") {
         // Create form data after SAML standard
         const formData = {
-          "RelayState": binding.value.relayState,
-          "SAMLResponse": binding.value.samlResponse,
+          RelayState: binding.value.relayState,
+          SAMLResponse: binding.value.samlResponse,
         };
 
         // Convert form data to URL-encoded string
         const formBody = Object.entries(formData)
-            .map(
-                ([key, value]) =>
-                    encodeURIComponent(key) + "=" + encodeURIComponent(value),
-            )
-            .join("&");
+          .map(
+            ([key, value]) =>
+              encodeURIComponent(key) + "=" + encodeURIComponent(value),
+          )
+          .join("&");
 
         // Make a POST request to the external URL with the form data
         const response = await fetch(url, {

--- a/apps/login/src/app/login/route.ts
+++ b/apps/login/src/app/login/route.ts
@@ -476,17 +476,17 @@ export async function GET(request: NextRequest) {
         return NextResponse.redirect(url);
       } else if (url && binding.case === "post") {
         const formData = {
-          relayState: binding.value.relayState,
-          samlResponse: binding.value.samlResponse,
+          "RelayState": binding.value.relayState,
+          "SAMLResponse": binding.value.samlResponse,
         };
 
-        // Convert form data to URL-encoded string
-        const formBody = new FormData();
+        const formBody = Object.entries(formData)
+            .map(
+                ([key, value]) =>
+                    encodeURIComponent(key) + "=" + encodeURIComponent(value),
+            )
+            .join("&");
 
-        formBody.append("RelayState", formData.relayState);
-        formBody.append("SAMLResponse", formData.samlResponse);
-        console.log(url)
-        console.log(formBody)
         // Make a POST request to the external URL with the form data
         const response = await fetch(url, {
           method: "POST",
@@ -495,7 +495,6 @@ export async function GET(request: NextRequest) {
           },
           body: formBody,
         });
-        console.log(response)
 
         // Handle the response from the external URL
         if (response.ok) {


### PR DESCRIPTION
This fixes the serializing function that creates the requestId from the samlRequest on the `/login` route

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [ ] Cypress integration tests ensure that login app pages work as expected on good and bad user inputs, ZITADEL responses or IDP redirects. The ZITADEL API is mocked, IDP redirects are simulated.
- [ ] Playwright acceptances tests ensure that the happy paths of common user journeys work as expected. The ZITADEL API is not mocked but IDP redirects are simulated.
- [ ] No debug or dead code
- [ ] My code has no repetitions
