### PR TITLE
chore: fix docker build pipeline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Generate stubs
+        run: pnpm generate
+
       - name: Build for Docker
         run: NEXT_PUBLIC_BASE_PATH=/ui/v2/login pnpm build:docker
 


### PR DESCRIPTION
This PR aims to fix the Docker build pipeline by ensuring that any required stubs are generated before the Docker build step is executed.

- Inserted a "Generate stubs" step that runs "pnpm generate" before building for Docker.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [x] Cypress integration tests ensure that login app pages work as expected on good and bad user inputs, ZITADEL responses or IDP redirects. The ZITADEL API is mocked, IDP redirects are simulated.
- [x] Playwright acceptances tests ensure that the happy paths of common user journeys work as expected. The ZITADEL API is not mocked but IDP redirects are simulated.
- [x] No debug or dead code
- [x] My code has no repetitions
