### PR TITLE
feat: configure internationalization for Moment.js

### DIFF
--- a/apps/login/src/components/session-item.tsx
+++ b/apps/login/src/components/session-item.tsx
@@ -6,10 +6,10 @@ import { XCircleIcon } from "@heroicons/react/24/outline";
 import { Timestamp, timestampDate } from "@zitadel/client";
 import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
 import moment from "moment";
+import { useLocale } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Avatar } from "./avatar";
-import { useLocale } from "next-intl";
 
 export function isSessionValid(session: Partial<Session>): {
   valid: boolean;

--- a/apps/login/src/components/session-item.tsx
+++ b/apps/login/src/components/session-item.tsx
@@ -9,6 +9,7 @@ import moment from "moment";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Avatar } from "./avatar";
+import { useLocale } from "next-intl";
 
 export function isSessionValid(session: Partial<Session>): {
   valid: boolean;
@@ -37,6 +38,9 @@ export function SessionItem({
   reload: () => void;
   requestId?: string;
 }) {
+  const currentLocale = useLocale();
+  moment.locale(currentLocale === "zh" ? "zh-cn" : currentLocale);
+
   const [loading, setLoading] = useState<boolean>(false);
 
   async function clearSession(id: string) {


### PR DESCRIPTION
Configures Moment.js [internationalization](https://momentjs.com/docs/#/i18n/) for all locales.
Since Moment.js supports multiple Chinese [variants](https://github.com/moment/moment/tree/develop/src/locale), this PR maps `zh` to `zh-cn` to ensure the correct locale is used.

![image](https://github.com/user-attachments/assets/706bc02d-214e-450a-9543-773c7bbf52e9)
![image](https://github.com/user-attachments/assets/3ff71f8f-39d5-4bf2-8ebc-8db123c3611a)
![image](https://github.com/user-attachments/assets/4a66be0c-fd2e-4a40-8b7f-04bfa54c35b1)
![image](https://github.com/user-attachments/assets/837b3422-208d-434d-9c97-b66c542d0c8a)
![image](https://github.com/user-attachments/assets/98f0c1cc-e990-4708-b7ac-785bf29535ac)


### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [ ] Cypress integration tests ensure that login app pages work as expected on good and bad user inputs, ZITADEL responses or IDP redirects. The ZITADEL API is mocked, IDP redirects are simulated.
- [ ] Playwright acceptances tests ensure that the happy paths of common user journeys work as expected. The ZITADEL API is not mocked but IDP redirects are simulated.
- [ ] No debug or dead code
- [ ] My code has no repetitions
