### PR TITLE
fix: enfore secure cookie for production environments

### DIFF
--- a/apps/login/src/lib/cookies.ts
+++ b/apps/login/src/lib/cookies.ts
@@ -31,7 +31,8 @@ async function setSessionHttpOnlyCookie<T>(
     value: JSON.stringify(sessions),
     httpOnly: true,
     path: "/",
-    sameSite,
+    sameSite: process.env.NODE_ENV === "production" ? sameSite : "lax",
+    secure: process.env.NODE_ENV === "production",
   });
 }
 

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,8 @@
     "ZITADEL_API_URL",
     "ZITADEL_SERVICE_USER_TOKEN",
     "NEXT_PUBLIC_BASE_PATH",
-    "CUSTOM_REQUEST_HEADERS"
+    "CUSTOM_REQUEST_HEADERS",
+    "NODE_ENV"
   ],
   "tasks": {
     "generate": {


### PR DESCRIPTION
This PR enforces secure cookies on production environments, especially if sameSite property is set to `none` which is required for the iFrame options.
