### PR TITLE
fix: Improve Invite flow by checking for same user agent and time limit

### DIFF
--- a/apps/login/src/components/register-passkey.tsx
+++ b/apps/login/src/components/register-passkey.tsx
@@ -83,6 +83,16 @@ export function RegisterPasskey({
       return;
     }
 
+    if ("error" in resp && resp.error) {
+      setError(resp.error);
+      return;
+    }
+
+    if (!("passkeyId" in resp)) {
+      setError("An error on registering passkey");
+      return;
+    }
+
     const passkeyId = resp.passkeyId;
     const options: CredentialCreationOptions =
       (resp.publicKeyCredentialCreationOptions as CredentialCreationOptions) ??
@@ -92,6 +102,7 @@ export function RegisterPasskey({
       setError("An error on registering passkey");
       return;
     }
+
     options.publicKey.challenge = coerceToArrayBuffer(
       options.publicKey.challenge,
       "challenge",

--- a/apps/login/src/lib/server/password.ts
+++ b/apps/login/src/lib/server/password.ts
@@ -13,7 +13,6 @@ import {
   listAuthenticationMethodTypes,
   listUsers,
   passwordReset,
-  setPassword,
   setUserPassword,
 } from "@/lib/zitadel";
 import { ConnectError, create } from "@zitadel/client";
@@ -25,13 +24,12 @@ import {
 } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
 import { LoginSettings } from "@zitadel/proto/zitadel/settings/v2/login_settings_pb";
 import { User, UserState } from "@zitadel/proto/zitadel/user/v2/user_pb";
-import {
-  AuthenticationMethodType,
-  SetPasswordRequestSchema,
-} from "@zitadel/proto/zitadel/user/v2/user_service_pb";
-import { headers } from "next/headers";
+import { SetPasswordRequestSchema } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
+import crypto from "crypto";
+import { cookies, headers } from "next/headers";
 import { getNextUrl } from "../client";
 import { getSessionCookieById, getSessionCookieByLoginName } from "../cookies";
+import { getFingerprintId } from "../fingerprint";
 import { getServiceUrlFromHeaders } from "../service-url";
 import {
   checkEmailVerification,
@@ -297,6 +295,7 @@ export async function sendPassword(command: UpdateSessionCommand) {
   return { redirect: url };
 }
 
+// this function lets users with code set a password or users with valid User Verification Check
 export async function changePassword(command: {
   code?: string;
   userId: string;
@@ -316,11 +315,50 @@ export async function changePassword(command: {
   }
   const userId = user.userId;
 
+  if (user.state === UserState.INITIAL) {
+    return { error: "User Initial State is not supported" };
+  }
+
+  // check if the user has no password set in order to set a password
+  if (!command.code) {
+    const authmethods = await listAuthenticationMethodTypes({
+      serviceUrl,
+      userId,
+    });
+
+    // if the user has no authmethods set, we need to check if the user was verified
+    // users are redirected from /authenticator/set to /password/set
+    if (authmethods.authMethodTypes.length !== 0) {
+      return {
+        error:
+          "You have to provide a code or have a valid User Verification Check",
+      };
+    }
+
+    // check if a verification was done earlier
+    const cookiesList = await cookies();
+    const userAgentId = await getFingerprintId();
+
+    const verificationCheck = crypto
+      .createHash("sha256")
+      .update(`${user.userId}:${userAgentId}`)
+      .digest("hex");
+
+    const cookieValue = await cookiesList.get("verificationCheck")?.value;
+
+    if (!cookieValue) {
+      return { error: "User Verification Check has to be done" };
+    }
+
+    if (cookieValue !== verificationCheck) {
+      return { error: "User Verification Check has to be done" };
+    }
+  }
+
   return setUserPassword({
     serviceUrl,
     userId,
     password: command.password,
-    user,
     code: command.code,
   });
 }
@@ -366,67 +404,32 @@ export async function checkSessionAndSetPassword({
     return { error: "Could not load auth methods" };
   }
 
-  const requiredAuthMethodsForForceMFA = [
-    AuthenticationMethodType.OTP_EMAIL,
-    AuthenticationMethodType.OTP_SMS,
-    AuthenticationMethodType.TOTP,
-    AuthenticationMethodType.U2F,
-  ];
-
-  const hasNoMFAMethods = requiredAuthMethodsForForceMFA.every(
-    (method) => !authmethods.authMethodTypes.includes(method),
-  );
-
-  const loginSettings = await getLoginSettings({
-    serviceUrl,
-    organization: session.factors.user.organizationId,
-  });
-
-  const forceMfa = !!(
-    loginSettings?.forceMfa || loginSettings?.forceMfaLocalOnly
-  );
-
-  // if the user has no MFA but MFA is enforced, we can set a password otherwise we use the token of the user
-  if (forceMfa && hasNoMFAMethods) {
-    return setPassword({ serviceUrl, payload }).catch((error) => {
-      // throw error if failed precondition (ex. User is not yet initialized)
-      if (error.code === 9 && error.message) {
-        return { error: "Failed precondition" };
-      } else {
-        throw error;
-      }
+  const transport = async (serviceUrl: string, token: string) => {
+    return createServerTransport(token, {
+      baseUrl: serviceUrl,
     });
-  } else {
-    const transport = async (serviceUrl: string, token: string) => {
-      return createServerTransport(token, {
-        baseUrl: serviceUrl,
-      });
-    };
+  };
 
-    const myUserService = async (serviceUrl: string, sessionToken: string) => {
-      const transportPromise = await transport(serviceUrl, sessionToken);
-      return createUserServiceClient(transportPromise);
-    };
+  const myUserService = async (serviceUrl: string, sessionToken: string) => {
+    const transportPromise = await transport(serviceUrl, sessionToken);
+    return createUserServiceClient(transportPromise);
+  };
 
-    const selfService = await myUserService(
-      serviceUrl,
-      `${sessionCookie.token}`,
-    );
+  const selfService = await myUserService(serviceUrl, `${sessionCookie.token}`);
 
-    return selfService
-      .setPassword(
-        {
-          userId: session.factors.user.id,
-          newPassword: { password, changeRequired: false },
-        },
-        {},
-      )
-      .catch((error: ConnectError) => {
-        console.log(error);
-        if (error.code === 7) {
-          return { error: "Session is not valid." };
-        }
-        throw error;
-      });
-  }
+  return selfService
+    .setPassword(
+      {
+        userId: session.factors.user.id,
+        newPassword: { password, changeRequired: false },
+      },
+      {},
+    )
+    .catch((error: ConnectError) => {
+      console.log(error);
+      if (error.code === 7) {
+        return { error: "Session is not valid." };
+      }
+      throw error;
+    });
 }

--- a/apps/login/src/lib/server/verify.ts
+++ b/apps/login/src/lib/server/verify.ts
@@ -21,7 +21,7 @@ import { User } from "@zitadel/proto/zitadel/user/v2/user_pb";
 import { cookies, headers } from "next/headers";
 import { getNextUrl } from "../client";
 import { getSessionCookieByLoginName } from "../cookies";
-import { getFingerprintId } from "../fingerprint";
+import { getOrSetFingerprintId } from "../fingerprint";
 import { getServiceUrlFromHeaders } from "../service-url";
 import { loadMostRecentSession } from "../session";
 import { checkMFAFactors } from "../verify-helper";
@@ -197,11 +197,9 @@ export async function sendVerification(command: VerifyUserByEmailCommand) {
       params.set("loginName", session.factors?.user?.loginName);
     }
 
-    // set hash of userId and userAgentId to prevent replay attacks, TODO: check on the /authenticator/set page
-
+    // set hash of userId and userAgentId to prevent attacks, checks are done for users with invalid sessions and invalid userAgentId
     const cookiesList = await cookies();
-
-    const userAgentId = await getFingerprintId();
+    const userAgentId = await getOrSetFingerprintId();
 
     const verificationCheck = crypto
       .createHash("sha256")

--- a/apps/login/src/lib/verify-helper.ts
+++ b/apps/login/src/lib/verify-helper.ts
@@ -4,7 +4,10 @@ import { LoginSettings } from "@zitadel/proto/zitadel/settings/v2/login_settings
 import { PasswordExpirySettings } from "@zitadel/proto/zitadel/settings/v2/password_settings_pb";
 import { HumanUser } from "@zitadel/proto/zitadel/user/v2/user_pb";
 import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
+import crypto from "crypto";
 import moment from "moment";
+import { cookies } from "next/headers";
+import { getOrSetFingerprintId } from "./fingerprint";
 import { getUserByID } from "./zitadel";
 
 export function checkPasswordChangeRequired(
@@ -44,7 +47,7 @@ export function checkPasswordChangeRequired(
   }
 }
 
-export function checkInvite(
+export function checkEmailVerified(
   session: Session,
   humanUser?: HumanUser,
   organization?: string,
@@ -247,4 +250,33 @@ export async function checkMFAFactors(
     // TODO: provide a way to setup passkeys on mfa page?
     return { redirect: `/mfa/set?` + params };
   }
+}
+
+export async function checkUserVerification(userId: string): Promise<boolean> {
+  // check if a verification was done earlier
+  const cookiesList = await cookies();
+  const userAgentId = await getOrSetFingerprintId();
+
+  const verificationCheck = crypto
+    .createHash("sha256")
+    .update(`${userId}:${userAgentId}`)
+    .digest("hex");
+
+  const cookieValue = await cookiesList.get("verificationCheck")?.value;
+
+  if (!cookieValue) {
+    console.warn(
+      "User verification check cookie not found. User verification check failed.",
+    );
+    return false;
+  }
+
+  if (cookieValue !== verificationCheck) {
+    console.warn(
+      `User verification check failed. Expected ${verificationCheck} but got ${cookieValue}`,
+    );
+    return false;
+  }
+
+  return true;
 }


### PR DESCRIPTION
This PR improves the invite flow by having a recent verification check via email or invite.
The PR implements a cookie with an expiration of 5 mins that is checked whenever a method is setup for the first time (zero auth method on the user). The cookie is set after a verification has successfully submitted, and is checked on the `/password/set` and `/passkey/set` pages.


### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [ ] Cypress integration tests ensure that login app pages work as expected on good and bad user inputs, ZITADEL responses or IDP redirects. The ZITADEL API is mocked, IDP redirects are simulated.
- [ ] Playwright acceptances tests ensure that the happy paths of common user journeys work as expected. The ZITADEL API is not mocked but IDP redirects are simulated.
- [ ] No debug or dead code
- [ ] My code has no repetitions
