### PR TITLE
fix: invite flow when expired

### DIFF
--- a/apps/login/src/app/(login)/verify/page.tsx
+++ b/apps/login/src/app/(login)/verify/page.tsx
@@ -6,7 +6,6 @@ import { VerifyRedirectButton } from "@/components/verify-redirect-button";
 import { sendEmailCode } from "@/lib/server/verify";
 import { getServiceUrlFromHeaders } from "@/lib/service-url";
 import { loadMostRecentSession } from "@/lib/session";
-import { checkUserVerification } from "@/lib/verify-helper";
 import {
   getBrandingSettings,
   getUserByID,
@@ -112,8 +111,6 @@ export default async function Page(props: { searchParams: Promise<any> }) {
     }
   }
 
-  const hasValidUserVerificationCheck = await checkUserVerification(id);
-
   const params = new URLSearchParams({
     userId: userId,
     initial: "true", // defines that a code is not required and is therefore not shown in the UI
@@ -172,7 +169,7 @@ export default async function Page(props: { searchParams: Promise<any> }) {
         )}
 
         {/* show a button to setup auth method for the user otherwise show the UI for reverifying */}
-        {human?.email?.isVerified && hasValidUserVerificationCheck ? (
+        {human?.email?.isVerified ? (
           // show page for already verified users
           <VerifyRedirectButton
             userId={id}

--- a/apps/login/src/components/verify-redirect-button.tsx
+++ b/apps/login/src/components/verify-redirect-button.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/server/verify";
 import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Alert, AlertType } from "./alert";
 import { BackButton } from "./back-button";
@@ -29,6 +30,7 @@ export function VerifyRedirectButton({
   const [error, setError] = useState<string>("");
 
   const [loading, setLoading] = useState<boolean>(false);
+  const router = useRouter();
 
   async function submitAndContinue(): Promise<boolean | void> {
     setLoading(true);
@@ -50,7 +52,7 @@ export function VerifyRedirectButton({
       } as SendVerificationRedirectWithoutCheckCommand;
     }
 
-    await sendVerificationRedirectWithoutCheck(command)
+    const response = await sendVerificationRedirectWithoutCheck(command)
       .catch(() => {
         setError("Could not verify");
         return;
@@ -58,6 +60,16 @@ export function VerifyRedirectButton({
       .finally(() => {
         setLoading(false);
       });
+
+    if (response && "error" in response && response.error) {
+      setError(response.error);
+      return;
+    }
+
+    if (response && "redirect" in response && response.redirect) {
+      router.push(response.redirect);
+      return true;
+    }
   }
 
   return (

--- a/apps/login/src/lib/server/verify.ts
+++ b/apps/login/src/lib/server/verify.ts
@@ -71,14 +71,16 @@ export async function sendVerification(command: VerifyUserByEmailCommand) {
         serviceUrl,
         userId: command.userId,
         verificationCode: command.code,
-      }).catch(() => {
+      }).catch((error) => {
+        console.warn(error);
         return { error: "Could not verify invite" };
       })
     : await verifyEmail({
         serviceUrl,
         userId: command.userId,
         verificationCode: command.code,
-      }).catch(() => {
+      }).catch((error) => {
+        console.warn(error);
         return { error: "Could not verify email" };
       });
 


### PR DESCRIPTION
Only show verification state when the invitation link is clicked multiple times. In the case of no auth methods, show button to jump to /authenticator/set where the user verification is rechecked and user is redirected to verify another time if necessary.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [ ] Cypress integration tests ensure that login app pages work as expected on good and bad user inputs, ZITADEL responses or IDP redirects. The ZITADEL API is mocked, IDP redirects are simulated.
- [ ] Playwright acceptances tests ensure that the happy paths of common user journeys work as expected. The ZITADEL API is not mocked but IDP redirects are simulated.
- [ ] No debug or dead code
- [ ] My code has no repetitions
