### PR TITLE
feat: Redis

### DIFF
--- a/apps/login/package.json
+++ b/apps/login/package.json
@@ -45,6 +45,7 @@
     "clsx": "1.2.1",
     "copy-to-clipboard": "^3.3.3",
     "deepmerge": "^4.3.1",
+    "ioredis": "^5.6.1",
     "jose": "^5.3.0",
     "lucide-react": "0.469.0",
     "moment": "^2.29.4",

--- a/apps/login/src/app/login/route.ts
+++ b/apps/login/src/app/login/route.ts
@@ -311,7 +311,9 @@ export async function GET(request: NextRequest) {
         );
 
         if (securitySettings?.embeddedIframe?.enabled) {
-          securitySettings.embeddedIframe.allowedOrigins;
+          console.log(
+            `Setting Content-Security-Policy for embedded iframe: frame-anchestors ${securitySettings.embeddedIframe.allowedOrigins.join(" ")}`,
+          );
           noSessionResponse.headers.set(
             "Content-Security-Policy",
             `${DEFAULT_CSP} frame-ancestors ${securitySettings.embeddedIframe.allowedOrigins.join(" ")};`,
@@ -350,7 +352,9 @@ export async function GET(request: NextRequest) {
         const callbackResponse = NextResponse.redirect(callbackUrl);
 
         if (securitySettings?.embeddedIframe?.enabled) {
-          securitySettings.embeddedIframe.allowedOrigins;
+          console.log(
+            `Setting Content-Security-Policy for embedded iframe: frame-anchestors ${securitySettings.embeddedIframe.allowedOrigins.join(" ")}`,
+          );
           callbackResponse.headers.set(
             "Content-Security-Policy",
             `${DEFAULT_CSP} frame-ancestors ${securitySettings.embeddedIframe.allowedOrigins.join(" ")};`,

--- a/apps/login/src/lib/etag.ts
+++ b/apps/login/src/lib/etag.ts
@@ -1,0 +1,30 @@
+import { DescMessage, StreamRequest, UnaryRequest } from "@zitadel/client";
+
+const etagCache = new Map<string, string>(); // TODO use a more sophisticated cache that works across cloud run instances
+
+export type AnyFn = (...args: any[]) => any;
+
+export const etagInterceptor =
+  (next: AnyFn) =>
+  async (
+    req:
+      | UnaryRequest<DescMessage, DescMessage>
+      | StreamRequest<DescMessage, DescMessage>,
+  ) => {
+    const url = req.url;
+    console.log("Etag interceptor for", url);
+    const etag = etagCache.get(url);
+
+    if (etag) {
+      req.header.set("if-none-match", etag);
+    }
+
+    const res = await next(req);
+
+    const newEtag = res.header.get("etag");
+    if (newEtag) {
+      etagCache.set(url, newEtag);
+    }
+
+    return res;
+  };

--- a/apps/login/src/lib/etag.ts
+++ b/apps/login/src/lib/etag.ts
@@ -1,8 +1,15 @@
 import { DescMessage, StreamRequest, UnaryRequest } from "@zitadel/client";
 
-const etagCache = new Map<string, string>(); // TODO use a more sophisticated cache that works across cloud run instances
-
 export type AnyFn = (...args: any[]) => any;
+
+type CachedEtag = { etag: string; expiresAt: number };
+const etagCache = new Map<string, CachedEtag>(); // TODO use Redis or similar for persistence
+
+function parseMaxAge(cacheControl: string | null): number | null {
+  if (!cacheControl) return null;
+  const match = cacheControl.match(/max-age=(\d+)/);
+  return match ? parseInt(match[1], 10) : null;
+}
 
 export const etagInterceptor =
   (next: AnyFn) =>
@@ -13,17 +20,25 @@ export const etagInterceptor =
   ) => {
     const url = req.url;
     console.log("Etag interceptor for", url);
-    const etag = etagCache.get(url);
 
-    if (etag) {
-      req.header.set("if-none-match", etag);
+    // Check if we have a non-expired etag
+    const cached = etagCache.get(url);
+    if (cached && cached.expiresAt > Date.now()) {
+      req.header.set("if-none-match", cached.etag);
+    } else if (cached) {
+      etagCache.delete(url); // Remove expired etag
     }
 
     const res = await next(req);
 
     const newEtag = res.header.get("etag");
+    const cacheControl = res.header.get("cache-control");
     if (newEtag) {
-      etagCache.set(url, newEtag);
+      const maxAge = parseMaxAge(cacheControl);
+      const expiresAt = maxAge
+        ? Date.now() + maxAge * 1000
+        : Date.now() + 60 * 1000; // default 60s
+      etagCache.set(url, { etag: newEtag, expiresAt });
     }
 
     return res;

--- a/apps/login/src/lib/redis.ts
+++ b/apps/login/src/lib/redis.ts
@@ -1,0 +1,9 @@
+import Redis from "ioredis";
+
+const redis = new Redis({
+  host: process.env.REDIS_HOST, // e.g., "10.0.0.2"
+  port: Number(process.env.REDIS_PORT) || 6379,
+  // password: process.env.REDIS_PASSWORD, // if set
+});
+
+export default redis;

--- a/apps/login/src/lib/redis.ts
+++ b/apps/login/src/lib/redis.ts
@@ -1,9 +1,14 @@
 import Redis from "ioredis";
 
-const redis = new Redis({
-  host: process.env.REDIS_HOST, // e.g., "10.0.0.2"
-  port: Number(process.env.REDIS_PORT) || 6379,
-  // password: process.env.REDIS_PASSWORD, // if set
-});
+let redis: Redis | null = null;
 
-export default redis;
+export function getRedis() {
+  if (!redis) {
+    redis = new Redis({
+      host: process.env.REDIS_HOST,
+      port: Number(process.env.REDIS_PORT) || 6379,
+      // password: process.env.REDIS_PASSWORD,
+    });
+  }
+  return redis;
+}

--- a/apps/login/src/lib/server/password.ts
+++ b/apps/login/src/lib/server/password.ts
@@ -133,7 +133,7 @@ export async function sendPassword(command: UpdateSessionCommand) {
         if ("failedAttempts" in error && error.failedAttempts) {
           const lockoutSettings = await getLockoutSettings({
             serviceUrl,
-            orgId: command.organization,
+            organization: command.organization,
           });
 
           return {
@@ -164,7 +164,7 @@ export async function sendPassword(command: UpdateSessionCommand) {
       if ("failedAttempts" in error && error.failedAttempts) {
         const lockoutSettings = await getLockoutSettings({
           serviceUrl,
-          orgId: command.organization,
+          organization: command.organization,
         });
 
         return {
@@ -211,7 +211,7 @@ export async function sendPassword(command: UpdateSessionCommand) {
 
   const expirySettings = await getPasswordExpirySettings({
     serviceUrl,
-    orgId: command.organization ?? session.factors?.user?.organizationId,
+    organization: command.organization ?? session.factors?.user?.organizationId,
   });
 
   // check if the user has to change password first

--- a/apps/login/src/lib/service.ts
+++ b/apps/login/src/lib/service.ts
@@ -1,4 +1,9 @@
-import { createClientFor } from "@zitadel/client";
+import {
+  createClientFor,
+  DescMessage,
+  StreamRequest,
+  UnaryRequest,
+} from "@zitadel/client";
 import { createServerTransport } from "@zitadel/client/node";
 import { IdentityProviderService } from "@zitadel/proto/zitadel/idp/v2/idp_service_pb";
 import { OIDCService } from "@zitadel/proto/zitadel/oidc/v2/oidc_service_pb";
@@ -8,6 +13,7 @@ import { SessionService } from "@zitadel/proto/zitadel/session/v2/session_servic
 import { SettingsService } from "@zitadel/proto/zitadel/settings/v2/settings_service_pb";
 import { UserService } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 import { systemAPIToken } from "./api";
+import { AnyFn, etagInterceptor } from "./etag";
 
 type ServiceClass =
   | typeof IdentityProviderService
@@ -43,23 +49,29 @@ export async function createServiceForHost<T extends ServiceClass>(
     throw new Error("No token found");
   }
 
+  const interceptors = [];
+
+  if (process.env.CUSTOM_REQUEST_HEADERS) {
+    interceptors.push((next: AnyFn) => {
+      return (
+        req:
+          | UnaryRequest<DescMessage, DescMessage>
+          | StreamRequest<DescMessage, DescMessage>,
+      ) => {
+        process.env.CUSTOM_REQUEST_HEADERS.split(",").forEach((header) => {
+          const kv = header.split(":");
+          req.header.set(kv[0], kv[1]);
+        });
+        return next(req);
+      };
+    });
+  }
+
+  interceptors.push(etagInterceptor);
+
   const transport = createServerTransport(token, {
     baseUrl: serviceUrl,
-    interceptors: !process.env.CUSTOM_REQUEST_HEADERS
-      ? undefined
-      : [
-          (next) => {
-            return (req) => {
-              process.env.CUSTOM_REQUEST_HEADERS.split(",").forEach(
-                (header) => {
-                  const kv = header.split(":");
-                  req.header.set(kv[0], kv[1]);
-                },
-              );
-              return next(req);
-            };
-          },
-        ],
+    interceptors: interceptors.length ? interceptors : undefined,
   });
 
   return createClientFor<T>(service)(transport);

--- a/apps/login/src/lib/zitadel.ts
+++ b/apps/login/src/lib/zitadel.ts
@@ -42,7 +42,7 @@ import {
   VerifyU2FRegistrationRequest,
 } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 import { getUserAgent } from "./fingerprint";
-import redis from "./redis";
+import { getRedis } from "./redis";
 import { createServiceForHost } from "./service";
 
 const useCache = process.env.REDIS_HOST && process.env.REDIS_PORT;
@@ -52,6 +52,7 @@ export async function getOrSetCache<T>(
   fetcher: () => Promise<T>,
   ttlSeconds = 3600,
 ): Promise<T> {
+  const redis = getRedis();
   const cached = await redis.get(key);
   if (cached) {
     return JSON.parse(cached) as T;

--- a/apps/login/src/lib/zitadel.ts
+++ b/apps/login/src/lib/zitadel.ts
@@ -45,14 +45,7 @@ import { getUserAgent } from "./fingerprint";
 import redis from "./redis";
 import { createServiceForHost } from "./service";
 
-const useCache = process.env.DEBUG !== "true";
-
-// async function cacheWrapper<T>(callback: Promise<T>) {
-//   "use cache";
-//   cacheLife("hours");
-
-//   return callback;
-// }
+const useCache = process.env.REDIS_HOST && process.env.REDIS_PORT;
 
 export async function getOrSetCache<T>(
   key: string,

--- a/packages/zitadel-client/src/index.ts
+++ b/packages/zitadel-client/src/index.ts
@@ -3,8 +3,16 @@ export { NewAuthorizationBearerInterceptor } from "./interceptors.js";
 
 // TODO: Move this to `./protobuf.ts` and export it from there
 export { create, fromJson, toJson } from "@bufbuild/protobuf";
-export type { JsonObject } from "@bufbuild/protobuf";
+export type { DescMessage, JsonObject } from "@bufbuild/protobuf";
 export type { GenService } from "@bufbuild/protobuf/codegenv1";
 export { TimestampSchema, timestampDate, timestampFromDate, timestampFromMs, timestampMs } from "@bufbuild/protobuf/wkt";
 export type { Duration, Timestamp } from "@bufbuild/protobuf/wkt";
-export type { Client, Code, ConnectError } from "@connectrpc/connect";
+export type {
+  Client,
+  Code,
+  ConnectError,
+  StreamRequest,
+  StreamResponse,
+  UnaryRequest,
+  UnaryResponse,
+} from "@connectrpc/connect";

--- a/packages/zitadel-client/src/node.ts
+++ b/packages/zitadel-client/src/node.ts
@@ -1,7 +1,6 @@
 import { createGrpcTransport, GrpcTransportOptions } from "@connectrpc/connect-node";
 import { importPKCS8, SignJWT } from "jose";
 import { NewAuthorizationBearerInterceptor } from "./interceptors.js";
-
 /**
  * Create a server transport using grpc with the given token and configuration options.
  * @param token

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
+      ioredis:
+        specifier: ^5.6.1
+        version: 5.6.1
       jose:
         specifier: ^5.3.0
         version: 5.8.0
@@ -962,6 +965,9 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@ioredis/commands@1.2.0':
+    resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1955,6 +1961,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2145,6 +2155,10 @@ packages:
 
   delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2889,6 +2903,10 @@ packages:
   intl-messageformat@10.7.7:
     resolution: {integrity: sha512-F134jIoeYMro/3I0h08D0Yt4N9o9pjddU/4IIxMMURqbAtI2wu70X8hvG1V48W49zXHXv3RKSF/po+0fDfsGjA==}
 
+  ioredis@5.6.1:
+    resolution: {integrity: sha512-UxC0Yv1Y4WRJiGQxQkP0hfdL0/5/6YvdfOOClRgJ0qppSarkhneSa6UvkMkms0AkdGimSH3Ikqm+6mkMmX7vGA==}
+    engines: {node: '>=12.22.0'}
+
   is-arguments@1.1.1:
     resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
     engines: {node: '>= 0.4'}
@@ -3214,6 +3232,12 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -3933,6 +3957,14 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   reflect.getprototypeof@1.0.6:
     resolution: {integrity: sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==}
     engines: {node: '>= 0.4'}
@@ -4154,6 +4186,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   start-server-and-test@2.0.11:
     resolution: {integrity: sha512-TN39gLzPhHAflxyOkE/oMfQGj+pj3JgF6qVicFH/JrXt7xXktidKXwqfRga+ve7lVA8+RgPZVc25VrEPRScaDw==}
@@ -5479,6 +5514,8 @@ snapshots:
   '@img/sharp-win32-x64@0.34.1':
     optional: true
 
+  '@ioredis/commands@1.2.0': {}
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -6462,6 +6499,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -6706,6 +6745,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   delegates@1.0.0: {}
+
+  denque@2.1.0: {}
 
   dequal@2.0.3: {}
 
@@ -7660,6 +7701,20 @@ snapshots:
       '@formatjs/icu-messageformat-parser': 2.9.4
       tslib: 2.8.1
 
+  ioredis@5.6.1:
+    dependencies:
+      '@ioredis/commands': 1.2.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.0(supports-color@5.5.0)
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   is-arguments@1.1.1:
     dependencies:
       call-bind: 1.0.7
@@ -7994,6 +8049,10 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.camelcase@4.3.0: {}
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.merge@4.6.2: {}
 
@@ -8582,6 +8641,12 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   reflect.getprototypeof@1.0.6:
     dependencies:
       call-bind: 1.0.7
@@ -8876,6 +8941,8 @@ snapshots:
       tweetnacl: 0.14.5
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   start-server-and-test@2.0.11:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,8 @@
     "ZITADEL_SERVICE_USER_TOKEN",
     "NEXT_PUBLIC_BASE_PATH",
     "CUSTOM_REQUEST_HEADERS",
+    "REDIS_HOST",
+    "REDIS_PORT",
     "NODE_ENV"
   ],
   "tasks": {


### PR DESCRIPTION
# Add Redis client setup using ioredis for Google Cloud Memorystore integration

This change introduces a redis.ts module that initializes and exports a Redis client using the ioredis library. The client is configured via environment variables (`REDIS_HOST`, `REDIS_PORT`, and optional `REDIS_PASSWORD`) to enable caching and shared state using Google Cloud Memorystore.