### PR TITLE
fix: use custom req headers in all server requests

### DIFF
--- a/apps/login/src/lib/service.ts
+++ b/apps/login/src/lib/service.ts
@@ -45,21 +45,6 @@ export async function createServiceForHost<T extends ServiceClass>(
 
   const transport = createServerTransport(token, {
     baseUrl: serviceUrl,
-    interceptors: !process.env.CUSTOM_REQUEST_HEADERS
-      ? undefined
-      : [
-          (next) => {
-            return (req) => {
-              process.env.CUSTOM_REQUEST_HEADERS.split(",").forEach(
-                (header) => {
-                  const kv = header.split(":");
-                  req.header.set(kv[0], kv[1]);
-                },
-              );
-              return next(req);
-            };
-          },
-        ],
   });
 
   return createClientFor<T>(service)(transport);

--- a/apps/login/src/lib/zitadel.ts
+++ b/apps/login/src/lib/zitadel.ts
@@ -1318,7 +1318,6 @@ export async function setPassword({
     UserService,
     serviceUrl,
   );
-
   return userService.setPassword(payload, {});
 }
 

--- a/packages/zitadel-client/env-vars.d.ts
+++ b/packages/zitadel-client/env-vars.d.ts
@@ -1,0 +1,9 @@
+namespace NodeJS {
+  interface ProcessEnv {
+    /**
+     * Optional: custom request headers to be added to every request
+     * Split by comma, key value pairs separated by colon
+     */
+    CUSTOM_REQUEST_HEADERS?: string;
+  }
+}

--- a/packages/zitadel-client/package.json
+++ b/packages/zitadel-client/package.json
@@ -57,12 +57,14 @@
     "@connectrpc/connect": "^2.0.0",
     "@connectrpc/connect-node": "^2.0.0",
     "@connectrpc/connect-web": "^2.0.0",
-    "jose": "^5.3.0",
-    "@zitadel/proto": "workspace:*"
+    "@zitadel/proto": "workspace:*",
+    "jose": "^5.3.0"
   },
   "devDependencies": {
+    "@bufbuild/buf": "^1.53.0",
     "@bufbuild/protocompile": "^0.0.1",
-    "@zitadel/tsconfig": "workspace:*",
-    "@zitadel/eslint-config": "workspace:*"
+    "@types/node": "^22.14.1",
+    "@zitadel/eslint-config": "workspace:*",
+    "@zitadel/tsconfig": "workspace:*"
   }
 }

--- a/packages/zitadel-client/src/node.ts
+++ b/packages/zitadel-client/src/node.ts
@@ -7,10 +7,29 @@ import { NewAuthorizationBearerInterceptor } from "./interceptors.js";
  * @param token
  * @param opts
  */
+
 export function createServerTransport(token: string, opts: GrpcTransportOptions) {
-  return createGrpcTransport({
+    return createGrpcTransport({
     ...opts,
-    interceptors: [...(opts.interceptors || []), NewAuthorizationBearerInterceptor(token)],
+    interceptors: [
+        !process.env.CUSTOM_REQUEST_HEADERS
+            ? []
+            : [
+              (next: any) => {
+                return (req: any) => {
+                    process.env.CUSTOM_REQUEST_HEADERS!.split(",").forEach(
+                      (header) => {
+                        const kv = header.split(":");
+                        req.header.set(kv[0], kv[1]);
+                      },
+                  );
+                  return next(req);
+                };
+              },
+            ],
+      opts.interceptors || [],
+      [NewAuthorizationBearerInterceptor(token)],
+      ].flat()
   });
 }
 

--- a/packages/zitadel-client/src/node.ts
+++ b/packages/zitadel-client/src/node.ts
@@ -19,7 +19,11 @@ export function createServerTransport(token: string, opts: GrpcTransportOptions)
               return (req: any) => {
                 process.env.CUSTOM_REQUEST_HEADERS!.split(",").forEach((header) => {
                   const kv = header.split(":");
-                  req.header.set(kv[0], kv[1]);
+                  if (kv.length === 2) {
+                    req.header.set(kv[0].trim(), kv[1].trim());
+                  } else {
+                    console.warn(`Skipping malformed header: ${header}`);
+                  }
                 });
                 return next(req);
               };

--- a/packages/zitadel-client/src/node.ts
+++ b/packages/zitadel-client/src/node.ts
@@ -9,27 +9,25 @@ import { NewAuthorizationBearerInterceptor } from "./interceptors.js";
  */
 
 export function createServerTransport(token: string, opts: GrpcTransportOptions) {
-    return createGrpcTransport({
+  return createGrpcTransport({
     ...opts,
     interceptors: [
-        !process.env.CUSTOM_REQUEST_HEADERS
-            ? []
-            : [
-              (next: any) => {
-                return (req: any) => {
-                    process.env.CUSTOM_REQUEST_HEADERS!.split(",").forEach(
-                      (header) => {
-                        const kv = header.split(":");
-                        req.header.set(kv[0], kv[1]);
-                      },
-                  );
-                  return next(req);
-                };
-              },
-            ],
+      !process.env.CUSTOM_REQUEST_HEADERS
+        ? []
+        : [
+            (next: any) => {
+              return (req: any) => {
+                process.env.CUSTOM_REQUEST_HEADERS!.split(",").forEach((header) => {
+                  const kv = header.split(":");
+                  req.header.set(kv[0], kv[1]);
+                });
+                return next(req);
+              };
+            },
+          ],
       opts.interceptors || [],
       [NewAuthorizationBearerInterceptor(token)],
-      ].flat()
+    ].flat(),
   });
 }
 

--- a/packages/zitadel-client/tsconfig.json
+++ b/packages/zitadel-client/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "@zitadel/tsconfig/tsup.json",
-  "include": ["./src/**/*"],
+  "include": [
+    "./src/**/*",
+    "env-vars.d.ts"
+  ],
   "exclude": ["dist", "build", "node_modules"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
         version: 0.5.7(tailwindcss@3.4.14)
       '@vercel/analytics':
         specifier: ^1.2.2
-        version: 1.3.1(next@15.4.0-canary.86(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0))(react@19.1.0)
+        version: 1.3.1(next@15.4.0-canary.86(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0))(react@19.1.0)
       '@zitadel/client':
         specifier: workspace:*
         version: link:../../packages/zitadel-client
@@ -109,13 +109,13 @@ importers:
         version: 2.30.1
       next:
         specifier: 15.4.0-canary.86
-        version: 15.4.0-canary.86(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0)
+        version: 15.4.0-canary.86(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0)
       next-intl:
         specifier: ^3.25.1
-        version: 3.26.5(next@15.4.0-canary.86(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0))(react@19.1.0)
+        version: 3.26.5(next@15.4.0-canary.86(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0))(react@19.1.0)
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@15.4.0-canary.86(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 0.2.1(next@15.4.0-canary.86(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       nice-grpc:
         specifier: 2.0.1
         version: 2.0.1
@@ -256,6 +256,9 @@ importers:
       '@bufbuild/protocompile':
         specifier: ^0.0.1
         version: 0.0.1(@bufbuild/buf@1.53.0)
+      '@types/node':
+        specifier: ^22.14.1
+        version: 22.14.1
       '@zitadel/eslint-config':
         specifier: workspace:*
         version: link:../zitadel-eslint-config
@@ -5989,11 +5992,11 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vercel/analytics@1.3.1(next@15.4.0-canary.86(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0))(react@19.1.0)':
+  '@vercel/analytics@1.3.1(next@15.4.0-canary.86(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0))(react@19.1.0)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
-      next: 15.4.0-canary.86(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0)
+      next: 15.4.0-canary.86(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0)
       react: 19.1.0
 
   '@vercel/git-hooks@1.0.0': {}
@@ -6061,7 +6064,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6589,10 +6592,6 @@ snapshots:
       supports-color: 8.1.1
 
   debug@4.3.7:
-    dependencies:
-      ms: 2.1.3
-
-  debug@4.4.0:
     dependencies:
       ms: 2.1.3
 
@@ -7278,7 +7277,7 @@ snapshots:
 
   follow-redirects@1.15.9(debug@4.4.0):
     optionalDependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
 
   for-each@0.3.3:
     dependencies:
@@ -7538,7 +7537,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7551,14 +7550,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7907,7 +7906,7 @@ snapshots:
     dependencies:
       chalk: 5.4.1
       commander: 13.1.0
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       execa: 8.0.1
       lilconfig: 3.1.3
       listr2: 8.3.2
@@ -8091,21 +8090,21 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next-intl@3.26.5(next@15.4.0-canary.86(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0))(react@19.1.0):
+  next-intl@3.26.5(next@15.4.0-canary.86(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0))(react@19.1.0):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.8
       negotiator: 1.0.0
-      next: 15.4.0-canary.86(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0)
+      next: 15.4.0-canary.86(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0)
       react: 19.1.0
       use-intl: 3.26.5(react@19.1.0)
 
-  next-themes@0.2.1(next@15.4.0-canary.86(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next-themes@0.2.1(next@15.4.0-canary.86(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      next: 15.4.0-canary.86(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0)
+      next: 15.4.0-canary.86(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  next@15.4.0-canary.86(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0):
+  next@15.4.0-canary.86(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.87.0):
     dependencies:
       '@next/env': 15.4.0-canary.86
       '@swc/helpers': 0.5.15
@@ -8113,7 +8112,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      styled-jsx: 5.1.6(react@19.1.0)
+      styled-jsx: 5.1.6(@babel/core@7.26.10)(react@19.1.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.4.0-canary.86
       '@next/swc-darwin-x64': 15.4.0-canary.86
@@ -8837,7 +8836,7 @@ snapshots:
       arg: 5.0.2
       bluebird: 3.7.2
       check-more-types: 2.24.0
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       execa: 5.1.1
       lazy-ass: 1.6.0
       ps-tree: 1.2.0
@@ -8943,10 +8942,12 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-jsx@5.1.6(react@19.1.0):
+  styled-jsx@5.1.6(@babel/core@7.26.10)(react@19.1.0):
     dependencies:
       client-only: 0.0.1
       react: 19.1.0
+    optionalDependencies:
+      '@babel/core': 7.26.10
 
   sucrase@3.35.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,9 @@ importers:
         specifier: ^5.3.0
         version: 5.8.0
     devDependencies:
+      '@bufbuild/buf':
+        specifier: ^1.53.0
+        version: 1.53.0
       '@bufbuild/protocompile':
         specifier: ^0.0.1
         version: 0.0.1(@bufbuild/buf@1.53.0)
@@ -6944,7 +6947,7 @@ snapshots:
       debug: 4.4.0(supports-color@5.5.0)
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.8.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-module-utils: 2.8.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.0
       is-bun-module: 1.1.0
@@ -6957,7 +6960,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
+  eslint-module-utils@2.8.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
@@ -6978,7 +6981,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-module-utils: 2.8.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3


### PR DESCRIPTION
The env variable CUSTOM_REQUEST_HEADERS is not used for all requests to Zitadel.
For example changing the password doesn't get the custom headers, because it calls createServerTransport by itself instead of using the central zitadel client.
To fix this, we move the interceptor into `createServerTransport` and support the env in the zitadel-client lib.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [ ] Cypress integration tests ensure that login app pages work as expected on good and bad user inputs, ZITADEL responses or IDP redirects. The ZITADEL API is mocked, IDP redirects are simulated.
- [ ] Playwright acceptances tests ensure that the happy paths of common user journeys work as expected. The ZITADEL API is not mocked but IDP redirects are simulated.
- [x] No debug or dead code
- [x] My code has no repetitions
