### PR TITLE
fix(i18n): locale context for custom translations

### DIFF
--- a/apps/login/src/i18n/request.ts
+++ b/apps/login/src/i18n/request.ts
@@ -15,6 +15,21 @@ export default getRequestConfig(async () => {
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
 
+  const languageHeader = await (await headers()).get(LANGUAGE_HEADER_NAME);
+  if (languageHeader) {
+    const headerLocale = languageHeader.split(",")[0].split("-")[0]; // Extract the language code
+    if (LANGS.map((l) => l.code).includes(headerLocale)) {
+      locale = headerLocale;
+    }
+  }
+
+  const languageCookie = cookiesList?.get(LANGUAGE_COOKIE_NAME);
+  if (languageCookie && languageCookie.value) {
+    if (LANGS.map((l) => l.code).includes(languageCookie.value)) {
+      locale = languageCookie.value;
+    }
+  }
+
   const i18nOrganization = _headers.get("x-zitadel-i18n-organization") || ""; // You may need to set this header in middleware
 
   let translations: JsonObject | {} = {};
@@ -30,21 +45,6 @@ export default getRequestConfig(async () => {
     }
   } catch (error) {
     console.warn("Error fetching custom translations:", error);
-  }
-
-  const languageHeader = await (await headers()).get(LANGUAGE_HEADER_NAME);
-  if (languageHeader) {
-    const headerLocale = languageHeader.split(",")[0].split("-")[0]; // Extract the language code
-    if (LANGS.map((l) => l.code).includes(headerLocale)) {
-      locale = headerLocale;
-    }
-  }
-
-  const languageCookie = cookiesList?.get(LANGUAGE_COOKIE_NAME);
-  if (languageCookie && languageCookie.value) {
-    if (LANGS.map((l) => l.code).includes(languageCookie.value)) {
-      locale = languageCookie.value;
-    }
   }
 
   const customMessages = translations;


### PR DESCRIPTION
This ensures that the locale code is correctly fetched from the fallback and cookie 

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [ ] Cypress integration tests ensure that login app pages work as expected on good and bad user inputs, ZITADEL responses or IDP redirects. The ZITADEL API is mocked, IDP redirects are simulated.
- [ ] Playwright acceptances tests ensure that the happy paths of common user journeys work as expected. The ZITADEL API is not mocked but IDP redirects are simulated.
- [ ] No debug or dead code
- [ ] My code has no repetitions
