### PR TITLE
fix: add out of the box IPv6 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir -p /.env-file && touch /.env-file/.env && chown -R nextjs:nodejs /.env
 COPY --chown=nextjs:nodejs ./scripts/ ./
 COPY --chown=nextjs:nodejs --from=build-out / ./
 USER nextjs
-ENV HOSTNAME="0.0.0.0" \
+ENV HOSTNAME="::0" \
     NEXT_PUBLIC_BASE_PATH="/ui/v2/login" \
     PORT=3000
 # TODO: Check healthy, not ready


### PR DESCRIPTION
Currently, the HTTP server is listening on IPv4 only. This PR makes it listen on IPv4 and IPv6.

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] Vitest unit tests ensure that components produce expected outputs on different inputs.
- [ ] Cypress integration tests ensure that login app pages work as expected on good and bad user inputs, ZITADEL responses or IDP redirects. The ZITADEL API is mocked, IDP redirects are simulated.
- [ ] Playwright acceptances tests ensure that the happy paths of common user journeys work as expected. The ZITADEL API is not mocked but IDP redirects are simulated.
- [X] No debug or dead code
- [X] My code has no repetitions
