### PR TITLE
Fix docker container error：Cannot find module '/runtime/apps/login/server.js'

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -8,4 +8,4 @@ if [ -n "${ZITADEL_SERVICE_USER_TOKEN_FILE}" ] && [ -f "${ZITADEL_SERVICE_USER_T
   export ZITADEL_SERVICE_USER_TOKEN=$(cat "${ZITADEL_SERVICE_USER_TOKEN_FILE}")
 fi
 
-exec node /runtime/apps/login/server.js
+exec node /runtime/server.js


### PR DESCRIPTION
After packaging with the project's Dockerfile, an error occurs when starting the container: Cannot find module '/runtime/apps/login/server.js'

After investigation, the issue is caused by an incorrect path.
