### PR TITLE
fix: organization id ignored in searchUsers by email/phone

### DIFF
--- a/src/lib/zitadel.ts
+++ b/src/lib/zitadel.ts
@@ -879,7 +879,7 @@ export async function searchUsers({
   }
 
   if (organizationId) {
-    queries.push(
+    emailAndPhoneQueries.push(
       create(SearchQuerySchema, {
         query: {
           case: "organizationIdQuery",


### PR DESCRIPTION
Error "Multiple users found" caused if there are 2 or more users in two different organizations. 
There is a simple issue in the code just fixed.
